### PR TITLE
Add code to retry failed Pub/Sub list tests

### DIFF
--- a/pubsub/spec/sample_spec.rb
+++ b/pubsub/spec/sample_spec.rb
@@ -32,16 +32,14 @@ describe "Pub/Sub sample" do
   end
 
   # Pub/Sub calls may not respond immediately.
-  # Wrap expectations that may require multiple attempts with #expect_with_retry.
+  # Wrap expectations that may require multiple attempts with this method.
   def expect_with_retry attempts: 5
-    begin
-      attempt_number ||= 0
-      yield
-    rescue RSpec::Expectations::ExpectationNotMetError
-      attempt_number += 1
-      retry if attempt_number < attempts
-      raise
-    end
+    attempt_number ||= 0
+    yield
+  rescue RSpec::Expectations::ExpectationNotMetError
+    attempt_number += 1
+    retry if attempt_number < attempts
+    raise
   end
 
   before :each do


### PR DESCRIPTION
Tests that list topics and subscriptions have failed on Travis, eg. [#119394146](https://travis-ci.org/GoogleCloudPlatform/ruby-docs-samples/jobs/119394146)

This change wraps expectations for listing topics and subscriptions in a simple retry incase the topic or subscription is not immediately available via the API.