### PR TITLE
Use gcloud beta app deploy for Endpoints

### DIFF
--- a/appengine/endpoints/README.md
+++ b/appengine/endpoints/README.md
@@ -40,7 +40,7 @@ Open the `swagger.yaml` file and in the `host` property, replace
 
 Then, deploy the sample using `gcloud`:
 
-    gcloud app deploy app.yaml
+    gcloud beta app deploy app.yaml
 
 Once deployed, you can access the application at https://YOUR-PROJECT-ID.appspot.com/.
 


### PR DESCRIPTION
Endpoints applications require use of "gcloud beta app deploy" to be deployed correctly.