### PR TITLE
Wrap Datastore insert and update samples in transactions

### DIFF
--- a/datastore/sample.rb
+++ b/datastore/sample.rb
@@ -141,17 +141,20 @@ def upsert
 end
 
 def insert
+  task = nil
   gcloud = Gcloud.new
   datastore = gcloud.datastore
 
   # [START insert]
-  task = datastore.entity "Task" do |t|
-    t["category"] = "Personal"
-    t["done"] = false
-    t["priority"] = 4
-    t["description"] = "Learn Cloud Datastore"
+  datastore.transaction do |tx|
+    task = datastore.entity "Task" do |t|
+      t["category"] = "Personal"
+      t["done"] = false
+      t["priority"] = 4
+      t["description"] = "Learn Cloud Datastore"
+    end
+    datastore.save task
   end
-  datastore.save task
   # [END insert]
 
   task
@@ -182,9 +185,11 @@ def update
   datastore.save task
 
   # [START update]
-  task = datastore.find "Task", "sampleTask"
-  task["priority"] = 5
-  datastore.save task
+  datastore.transaction do |tx|
+    task = datastore.find "Task", "sampleTask"
+    task["priority"] = 5
+    datastore.save task
+  end
   # [END update]
 
   task


### PR DESCRIPTION
These samples actually run an upsert because they use `datastore.save`
rather than explicitly calling #insert and #update.  `datastore.save` is
the correct, simple idiomatic sample but these samples execute multiple
queries against Datastore rather than one so they should be wrapped in
transactions.  If either query fails, the entire transaction will be
rolled back and an exception will be raised.