### PR TITLE
Add firebase auth support to endpoints sample.

### DIFF
--- a/appengine/endpoints/Gemfile
+++ b/appengine/endpoints/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "sinatra"
 gem "json"
+gem "rack-cors"
 
 # Dependencies for ./clients/
 group :development do

--- a/appengine/endpoints/Gemfile.lock
+++ b/appengine/endpoints/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
     multipart-post (2.0.0)
     netrc (0.11.0)
     rack (1.6.4)
+    rack-cors (0.4.0)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
@@ -58,6 +59,7 @@ PLATFORMS
 
 DEPENDENCIES
   json
+  rack-cors
   rack-test
   rest-client
   rspec

--- a/appengine/endpoints/app.rb
+++ b/appengine/endpoints/app.rb
@@ -20,9 +20,19 @@
 require "base64"
 require "json"
 require "sinatra"
+require "rack/cors"
 
 before do
   content_type :json
+end
+
+use Rack::Cors do
+  allow do
+    origins "*"
+    resource "/auth/info/firebase",
+             :headers => :any,
+             :methods => [:get, :post, :options]
+  end
 end
 
 # Simple echo service.
@@ -53,6 +63,20 @@ end
 
 # Auth info with Google ID token.
 get "/auth/info/googleidtoken" do
+  auth_info
+end
+
+# Auth info with Firebase Auth.
+get "/auth/info/firebase" do
+  auth_info
+end
+
+options "/auth/info/firebase" do
+  200
+end
+
+# Auth info with Auth0.
+get "/auth/info/auth0" do
   auth_info
 end
 

--- a/appengine/endpoints/spec/endpoint_sample_spec.rb
+++ b/appengine/endpoints/spec/endpoint_sample_spec.rb
@@ -68,4 +68,47 @@ RSpec.describe "Ruby Endpoints Sample" do
     expect(error["error"]).to eq 500
     expect(error["message"]).to include "unexpected token"
   end
+
+  it "handles Firebase Auth" do
+    get "/auth/info/firebase"
+
+    expect(last_response.status).to eq 200
+    expect(last_response.content_type).to eq "application/json"
+    expect(last_response.body).to eq '{"id":"anonymous"}'
+
+    user_info = Base64.encode64 '{"id":"the user info"}'
+
+    header "X-Endpoint-API-UserInfo", user_info
+
+    get "/auth/info/firebase"
+
+    expect(last_response.status).to eq 200
+    expect(last_response.content_type).to eq "application/json"
+    expect(last_response.body).to eq '{"id":"the user info"}'
+
+
+    header "Origin", "example.com"
+    options "/auth/info/firebase"
+    expect(last_response.status).to eq 200
+    expect(last_response.headers["Access-Control-Allow-Origin"]).to eq "example.com"
+    expect(last_response.headers["Access-Control-Allow-Methods"]).to eq "GET, POST, OPTIONS"
+  end
+
+  it "GET /auth/info/auth0 renders user info" do
+    get "/auth/info/auth0"
+
+    expect(last_response.status).to eq 200
+    expect(last_response.content_type).to eq "application/json"
+    expect(last_response.body).to eq '{"id":"anonymous"}'
+
+    user_info = Base64.encode64 '{"id":"the user info"}'
+
+    header "X-Endpoint-API-UserInfo", user_info
+
+    get "/auth/info/auth0"
+
+    expect(last_response.status).to eq 200
+    expect(last_response.content_type).to eq "application/json"
+    expect(last_response.body).to eq '{"id":"the user info"}'
+  end
 end

--- a/appengine/endpoints/swagger.yaml
+++ b/appengine/endpoints/swagger.yaml
@@ -64,6 +64,37 @@ paths:
           # Your OAuth2 client's Client ID must be added here. You can add
           # multiple client IDs to accept tokens from multiple clients.
           - "YOUR-CLIENT-ID"
+  "/auth/info/firebase":
+    get:
+      description: "Returns the requests' authentication information."
+      operationId: "authInfoFirebase"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "Authentication info."
+          schema:
+            $ref: "#/definitions/authInfoResponse"
+      x-security:
+      - firebase:
+          audiences:
+          - "YOUR-PROJECT-ID"
+  "/auth/info/auth0":
+    get:
+      description: "Returns the requests' authentication information."
+      operationId: "auth_info_auth0_jwk"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "Authentication info."
+          schema:
+            $ref: "#/definitions/authInfoResponse"
+      x-security:
+      - auth0_jwk:
+          audiences:
+          # Replace with your client ID, found in the Auth0 console.
+          - "YOUR-CLIENT-ID"
 definitions:
   echoMessage:
     properties:
@@ -103,3 +134,19 @@ securityDefinitions:
     flow: "implicit"
     type: "oauth2"
     x-issuer: "https://accounts.google.com"
+  # This section configures authentication using Firebase Auth.
+  firebase:
+    authorizationUrl: ""
+    flow: "implicit"
+    type: "oauth2"
+    x-issuer: "https://securetoken.google.com/YOUR-PROJECT-ID"
+    x-jwks_uri: "https://www.googleapis.com/service_accounts/v1/metadata/x509/securetoken@system.gserviceaccount.com"
+      # This section configures authentication using Auth0 (https://auth0.com).
+  auth0_jwk:
+    # Update YOUR-ACCOUNT-NAME with your Auth0 account name.
+    authorizationUrl: "https://YOUR-ACCOUNT-NAME.auth0.com/authorize"
+    flow: "implicit"
+    type: "oauth2"
+    x-issuer: "https://YOUR-ACCOUNT-NAME.auth0.com/"
+    # Update this with your service account's email address.
+    x-jwks_uri: "https://YOUR-ACCOUNT-NAME.auth0.com/.well-known/jwks.json"


### PR DESCRIPTION
I couldn't find any example clients or docs for testing firebase auth in the Python or Go examples, so going with this until we have more docs on https://cloud.google.com/endpoints/docs/authenticating-users
