### PR TITLE
Copy Endpoints Ruby Echo sample to a new location and make it generic.

### DIFF
--- a/endpoints/getting-started/Dockerfile.custom
+++ b/endpoints/getting-started/Dockerfile.custom
@@ -1,13 +1,17 @@
 FROM debian:jessie
 
+ENV RACK_ENV production
+
 RUN apt-get update && \
     apt-get install -y build-essential ruby ruby-dev && \
     apt-get clean && \
     rm /var/lib/apt/lists/*_*
 
-ADD . /app
+COPY Gemfile Gemfile.lock /app/
 WORKDIR /app
-
 RUN gem install bundler && \
     bundle install
+
+COPY * /app/
+
 ENTRYPOINT ["bundle", "exec", "ruby", "app.rb", "-p", "8081"]

--- a/endpoints/getting-started/Dockerfile.custom
+++ b/endpoints/getting-started/Dockerfile.custom
@@ -1,0 +1,13 @@
+FROM debian:jessie
+
+RUN apt-get update && \
+    apt-get install -y build-essential ruby ruby-dev && \
+    apt-get clean && \
+    rm /var/lib/apt/lists/*_*
+
+ADD . /app
+WORKDIR /app
+
+RUN gem install bundler && \
+    bundle install
+ENTRYPOINT ["bundle", "exec", "ruby", "app.rb", "-p", "8081"]

--- a/endpoints/getting-started/Gemfile
+++ b/endpoints/getting-started/Gemfile
@@ -1,0 +1,16 @@
+source "https://rubygems.org"
+
+gem "sinatra"
+gem "json"
+
+# Dependencies for ./clients/
+group :development do
+  gem "rest-client"
+  gem "signet"
+end
+
+# Dependencies for ./spec/
+group :test do
+  gem "rspec"
+  gem "rack-test"
+end

--- a/endpoints/getting-started/Gemfile.lock
+++ b/endpoints/getting-started/Gemfile.lock
@@ -1,0 +1,68 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.4.0)
+    diff-lcs (1.2.5)
+    domain_name (0.5.20160826)
+      unf (>= 0.0.5, < 1.0.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    json (2.0.2)
+    jwt (1.5.6)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    netrc (0.11.0)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rest-client (2.0.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.3)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    signet (0.7.3)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      multi_json (~> 1.10)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    tilt (2.0.5)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json
+  rack-test
+  rest-client
+  rspec
+  signet
+  sinatra
+
+BUNDLED WITH
+   1.12.5

--- a/endpoints/getting-started/README.md
+++ b/endpoints/getting-started/README.md
@@ -1,0 +1,112 @@
+# Google Cloud Endpoints & Ruby
+
+This sample demonstrates how to use Google Cloud Endpoints with a Ruby backend. This sample requires that you have [Ruby](https://www.ruby-lang.org/en/documentation/installation/) 2.0.0 or newer installed.
+
+This sample consists of two parts:
+
+1. The backend
+2. The clients
+
+## Running locally
+
+### Running the backend
+
+Install all the dependencies:
+
+    $ bundle install
+
+Run the application:
+
+    $ bundle exec ruby app.rb -p 8080
+
+### Using the echo client
+
+With the app running locally, you can execute the simple echo client using:
+
+    $ bundle exec ruby clients/echo_client.rb \
+        --host http://localhost:8080 \
+        --api_key APIKEY \
+        --message "message to echo"
+
+The `APIKEY` doesn't matter as the endpoint proxy is not running to do authentication.
+
+## Deploying to Google Cloud Platform
+
+### Deploying to Google App Engine Flexible
+
+Follow the [Endpoints for App Engine Flexible Environment](https://cloud.google.com/endpoints/docs/quickstart-app-engine) quickstart.
+
+### Deploying to Google Container Engine
+
+Follow the [Endpoints for Container Engine](https://cloud.google.com/endpoints/docs/quickstart-container-engine) quickstart.
+
+### Deploying to Google Compute Engine
+
+Follow the [Endpoints for Compute Engine](https://cloud.google.com/endpoints/docs/quickstart-compute-engine) quickstart.
+
+### Deploying to Google Compute Engine with Docker
+
+Follow the [Endpoints for Compute Engine with Docker](https://cloud.google.com/endpoints/docs/quickstart-compute-engine-docker) quickstart.
+
+### Using the echo client
+
+With the project deployed, you'll need to create an API key to access the API.
+
+1. Open the Credentials page of the API Manager in the [Cloud Console](https://console.cloud.google.com/apis/credentials).
+2. Click 'Create credentials'.
+3. Select 'API Key'.
+4. Choose 'Server Key'
+
+With the API key, you can use the echo client to access the API:
+
+    $ bundle exec ruby clients/echo_client.rb \
+        --host https://YOUR-PROJECT-ID.appspot.com \
+        --api_key YOUR-API-KEY \
+        --message "message to echo"
+
+### Using the JWT client.
+
+The JWT client demonstrates how to use service accounts to authenticate to endpoints. To use the client, you'll need both an API key (as described in the echo client section) and a service account. To create a service account:
+
+1. Open the Credentials page of the API Manager in the [Cloud Console](https://console.cloud.google.com/apis/credentials).
+2. Click 'Create credentials'.
+3. Select 'Service account key'.
+4. In the 'Select service account' dropdown, select 'Create new service account'.
+5. Choose 'JSON' for the key type.
+
+To use the service account for authentication:
+
+1. Update the `google_jwt`'s `x-jwks_uri` in `swagger.yaml` with your service account's email address.
+2. Redeploy your application.
+
+Now you can use the JWT client to make requests to the API:
+
+    $ bundle exec ruby clients/google_jwt_client.rb \
+        --host https://YOUR-PROJECT-ID.appspot.com \
+        --api_key YOUR-API-KEY \
+        --service_account_file /path/to/service-account.json
+
+### Using the ID Token client.
+
+The ID Token client demonstrates how to use user credentials to authenticate to endpoints. To use the client, you'll need both an API key (as described in the echo client section) and a OAuth2 client ID. To create a client ID:
+
+1. Open the Credentials page of the API Manager in the [Cloud Console](https://console.cloud.google.com/apis/credentials).
+2. Click 'Create credentials'.
+3. Select 'OAuth client ID'.
+4. Choose 'Other' for the application type.
+
+To use the client ID for authentication:
+
+1. Update the `/auth/info/googleidtoken`'s `audiences` in `swagger.yaml` with your client ID.
+2. Redeploy your application.
+
+Now you can use the client ID to make requests to the API:
+
+    $ bundle exec ruby clients/google_id_token_client.rb \
+        --host https://YOUR-PROJECT-ID.appspot.com \
+        --api_key YOUR-API-KEY \
+        --client_secrets_file /path/to/client_secrets.json
+
+## Swagger UI
+
+The Swagger UI is an open source Swagger project that allows you to explore your API through a UI. Find out more about it on the [Swagger site](http://swagger.io/swagger-ui/).

--- a/endpoints/getting-started/app.rb
+++ b/endpoints/getting-started/app.rb
@@ -1,0 +1,63 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Google Cloud Endpoints sample application.
+#
+# Demonstrates how to create a simple echo API as well as how to deal with
+# various authentication methods.
+
+require "base64"
+require "json"
+require "sinatra"
+
+before do
+  content_type :json
+end
+
+# Simple echo service.
+post "/echo" do
+  message = JSON.parse(request.body.read)["message"]
+
+  { message: message }.to_json
+end
+
+# Retrieves the authenication information from Google Cloud Endpoints.
+def auth_info
+  encoded_info = request.env["HTTP_X_ENDPOINT_API_USERINFO"]
+
+  if encoded_info
+    info_json = Base64.decode64 encoded_info
+    user_info = JSON.parse info_json
+  else
+    user_info = { id: "anonymous" }
+  end
+
+  user_info.to_json
+end
+
+# Auth info with Google signed JWT.
+get "/auth/info/googlejwt" do
+  auth_info
+end
+
+# Auth info with Google ID token.
+get "/auth/info/googleidtoken" do
+  auth_info
+end
+
+# Handle exceptions by returning swagger-compliant json.
+error do
+  status 500
+  { error: 500, message: env["sinatra.error"].message }.to_json
+end

--- a/endpoints/getting-started/app.yaml
+++ b/endpoints/getting-started/app.yaml
@@ -1,0 +1,9 @@
+runtime: ruby
+vm: true
+entrypoint: bundle exec ruby app.rb -p $PORT
+
+beta_settings:
+  # Enable Google Cloud Endpoints API management.
+  use_endpoints_api_management: true
+  # Specify the Swagger API specification.
+  endpoints_swagger_spec_file: swagger.yaml

--- a/endpoints/getting-started/clients/echo_client.rb
+++ b/endpoints/getting-started/clients/echo_client.rb
@@ -1,0 +1,66 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example of calling a simple Google Cloud Endpoint API.
+
+require "json"
+require "optparse"
+require "rest-client"
+
+options = {}
+
+optparse = OptionParser.new do |opts|
+  opts.on("-h", "--host HOST",
+          "Your API host, e.g. https://your-project.appspot.com.") do |host|
+    options[:host] = host
+  end
+  opts.on("-k", "--api_key KEY", "Your API key.") do |api_key|
+    options[:api_key] = api_key
+  end
+  opts.on("-m", "--message MESSAGE", "Message to echo.") do |message|
+    options[:message] = message
+  end
+end
+
+optparse.parse!
+
+unless options[:host]
+  puts optparse
+  puts "Missing argument: host"
+  exit
+end
+
+unless options[:api_key]
+  puts optparse
+  puts "Missing argument: api_key"
+  exit
+end
+
+options[:message] = "Hello echo message" unless options[:message]
+
+url = "#{options[:host]}/echo?key=#{options[:api_key]}"
+body = { message: options[:message] }.to_json
+
+begin
+  response = RestClient.post url, body
+  puts response.code
+  puts response.body
+rescue StandardError => ex
+  if ex.respond_to? :response
+    puts ex.response.code
+    puts ex.response.body
+  else
+    puts ex
+  end
+end

--- a/endpoints/getting-started/clients/google_id_token_client.rb
+++ b/endpoints/getting-started/clients/google_id_token_client.rb
@@ -1,0 +1,104 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example of calling a Google Cloud Endpoint API with an ID token obtained
+# using the Google OAuth2 flow.
+
+require "optparse"
+require "rest-client"
+require "json"
+require "signet/oauth_2/client"
+require "openssl"
+
+options = {}
+
+optparse = OptionParser.new do |opts|
+  opts.on("-h", "--host HOST",
+          "Your API host, e.g. https://your-project.appspot.com.") do |host|
+    options[:host] = host
+  end
+  opts.on("-k", "--api_key KEY", "Your API key.") do |api_key|
+    options[:api_key] = api_key
+  end
+  opts.on("-s", "--client_secrets_file FILE",
+          "The path to your service account json file.") do |file_path|
+    options[:client_secrets_file] = file_path
+  end
+  opts.on("-m", "--message MESSAGE", "Message to echo.") do |message|
+    options[:message] = message
+  end
+end
+
+optparse.parse!
+
+unless options[:host]
+  puts optparse
+  puts "Missing argument: host"
+  exit
+end
+
+unless options[:api_key]
+  puts optparse
+  puts "Missing argument: api_key"
+  exit
+end
+
+unless options[:client_secrets_file]
+  puts optparse
+  puts "Missing argument: client_secrets_file"
+  exit
+end
+
+client_secrets = JSON.parse File.read(options[:client_secrets_file])
+
+oauth = Signet::OAuth2::Client.new(
+  issuer:               "jwt-client.endpoints.sample.google.com",
+  audience:             "echo.endpoints.sample.google.com",
+  scope:                "email",
+  authorization_uri:    "https://accounts.google.com/o/oauth2/auth",
+  token_credential_uri: "https://www.googleapis.com/oauth2/v4/token",
+  client_id:            client_secrets["installed"]["client_id"],
+  client_secret:        client_secrets["installed"]["client_secret"],
+  redirect_uri:         "urn:ietf:wg:oauth:2.0:oob"
+)
+
+puts "Open the following URI in your browser to get the authorization code:"
+puts oauth.authorization_uri
+
+print "Enter authorization code: "
+
+oauth.code = gets.chomp
+
+puts oauth.code
+
+oauth.fetch_access_token!
+
+puts oauth.id_token
+
+# Makes a request to the auth info endpoint for Google ID tokens.
+
+url = "#{options[:host]}/auth/info/googleidtoken?key=#{options[:api_key]}"
+
+begin
+  response = RestClient.get url, Authorization: "Bearer #{oauth.id_token}"
+  puts response.code
+  puts response.body
+rescue StandardError => ex
+  if ex.respond_to? :response
+    puts ex.response.code
+    puts ex.response.body
+  else
+    puts ex
+  end
+end

--- a/endpoints/getting-started/clients/google_jwt_client.rb
+++ b/endpoints/getting-started/clients/google_jwt_client.rb
@@ -1,0 +1,94 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#  Example of calling a Google Cloud Endpoint API with a JWT signed by
+# a Google API Service Account.
+
+require "optparse"
+require "rest-client"
+require "json"
+require "signet/oauth_2/client"
+require "openssl"
+
+options = {}
+
+optparse = OptionParser.new do |opts|
+  opts.on("-h", "--host HOST",
+          "Your API host, e.g. https://your-project.appspot.com.") do |host|
+    options[:host] = host
+  end
+  opts.on("-k", "--api_key KEY", "Your API key.") do |api_key|
+    options[:api_key] = api_key
+  end
+  opts.on("-s", "--service_account_file FILE",
+          "The path to your service account json file.") do |file_path|
+    options[:service_account_file] = file_path
+  end
+  opts.on("-m", "--message MESSAGE", "Message to echo.") do |message|
+    options[:message] = message
+  end
+end
+
+optparse.parse!
+
+unless options[:host]
+  puts optparse
+  puts "Missing argument: host"
+  exit
+end
+
+unless options[:api_key]
+  puts optparse
+  puts "Missing argument: api_key"
+  exit
+end
+
+unless options[:service_account_file]
+  puts optparse
+  puts "Missing argument: service_account_file"
+  exit
+end
+
+# Generate a signed JSON Web Token using a Google API Service Account.
+service_account = JSON.parse File.read(options[:service_account_file])
+
+oauth = Signet::OAuth2::Client.new(
+  issuer:               "jwt-client.endpoints.sample.google.com",
+  audience:             "echo.endpoints.sample.google.com",
+  scope:                "email",
+  authorization_uri:    "https://accounts.google.com/o/oauth2/auth",
+  token_credential_uri: "https://www.googleapis.com/oauth2/v4/token",
+  client_id:            service_account["client_id"],
+  signing_key:          OpenSSL::PKey::RSA.new(service_account["private_key"]),
+  sub:                  "123456"
+)
+
+jwt = oauth.to_jwt
+
+# Makes a request to the auth info endpoint for Google JWTs.
+
+url = "#{options[:host]}/auth/info/googlejwt?key=#{options[:api_key]}"
+
+begin
+  response = RestClient.get url, Authorization: "Bearer #{jwt}"
+  puts response.code
+  puts response.body
+rescue StandardError => ex
+  if ex.respond_to? :response
+    puts ex.response.code
+    puts ex.response.body
+  else
+    puts ex
+  end
+end

--- a/endpoints/getting-started/container-engine.yaml
+++ b/endpoints/getting-started/container-engine.yaml
@@ -38,6 +38,7 @@ spec:
         app: esp-echo
     spec:
       containers:
+      # [START esp]
       - name: esp
         image: b.gcr.io/endpoints/endpoints-runtime:0.3
         args: [
@@ -46,6 +47,7 @@ spec:
           "-s", "SERVICE_NAME",
           "-v", "SERVICE_VERSION",
         ]
+      # [END esp]
         ports:
           - containerPort: 8080
       - name: echo

--- a/endpoints/getting-started/container-engine.yaml
+++ b/endpoints/getting-started/container-engine.yaml
@@ -51,6 +51,6 @@ spec:
         ports:
           - containerPort: 8080
       - name: echo
-        image: b.gcr.io/endpoints/echo:latest
+        image: gcr.io/google-samples/echo-ruby:1.0
         ports:
           - containerPort: 8081

--- a/endpoints/getting-started/gke.yaml
+++ b/endpoints/getting-started/gke.yaml
@@ -1,0 +1,54 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: esp-echo
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: esp-echo
+  type: LoadBalancer
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: esp-echo
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: esp-echo
+    spec:
+      containers:
+      - name: esp
+        image: b.gcr.io/endpoints/endpoints-runtime:0.3
+        args: [
+          "-p", "8080",
+          "-a", "127.0.0.1:8081",
+          "-s", "SERVICE_NAME",
+          "-v", "SERVICE_VERSION",
+        ]
+        ports:
+          - containerPort: 8080
+      - name: echo
+        image: b.gcr.io/endpoints/echo:latest
+        ports:
+          - containerPort: 8081

--- a/endpoints/getting-started/gke.yaml
+++ b/endpoints/getting-started/gke.yaml
@@ -25,7 +25,7 @@ spec:
   selector:
     app: esp-echo
   type: LoadBalancer
-
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/endpoints/getting-started/spec/endpoint_sample_spec.rb
+++ b/endpoints/getting-started/spec/endpoint_sample_spec.rb
@@ -1,0 +1,71 @@
+require_relative "../app"
+
+require "rspec"
+require "rack/test"
+
+describe "Ruby Endpoints Sample" do
+  include Rack::Test::Methods
+
+  attr_reader :app
+
+  before :all do
+    @app = Sinatra::Application
+    @app.set :environment, :production
+  end
+
+  it "POST /echo renders message from request body" do
+    post "/echo", '{"message":"hello from test"}'
+
+    expect(last_response.status).to eq 200
+    expect(last_response.content_type).to eq "application/json"
+    expect(last_response.body).to eq '{"message":"hello from test"}'
+  end
+
+  it "GET /auth/info/googlejwt renders user info" do
+    get "/auth/info/googlejwt"
+
+    expect(last_response.status).to eq 200
+    expect(last_response.content_type).to eq "application/json"
+    expect(last_response.body).to eq '{"id":"anonymous"}'
+
+    user_info = Base64.encode64 '{"id":"the user info"}'
+
+    header "X-Endpoint-API-UserInfo", user_info
+
+    get "/auth/info/googlejwt"
+
+    expect(last_response.status).to eq 200
+    expect(last_response.content_type).to eq "application/json"
+    expect(last_response.body).to eq '{"id":"the user info"}'
+  end
+
+  it "GET /auth/info/googleidtoken renders user info" do
+    get "/auth/info/googleidtoken"
+
+    expect(last_response.status).to eq 200
+    expect(last_response.content_type).to eq "application/json"
+    expect(last_response.body).to eq '{"id":"anonymous"}'
+
+    user_info = Base64.encode64 '{"id":"the user info"}'
+
+    header "X-Endpoint-API-UserInfo", user_info
+
+    get "/auth/info/googleidtoken"
+
+    expect(last_response.status).to eq 200
+    expect(last_response.content_type).to eq "application/json"
+    expect(last_response.body).to eq '{"id":"the user info"}'
+  end
+
+  it "handles exceptions by returning Swagger-compliant JSON" do
+    post "/echo", '{"...invalid JSON'
+
+    expect(last_response.status).to eq 500
+    expect(last_response.content_type).to eq "application/json"
+
+    error = JSON.parse last_response.body
+
+    expect(error["error"]).to eq 500
+    expect(error["message"]).to include "unexpected token"
+  end
+end

--- a/endpoints/getting-started/swagger.yaml
+++ b/endpoints/getting-started/swagger.yaml
@@ -1,9 +1,11 @@
+# [START swagger]
 swagger: "2.0"
 info:
   description: "A simple Google Cloud Endpoints API example."
   title: "Endpoints Example"
   version: "1.0.0"
 host: "YOUR-PROJECT-ID.appspot.com"
+# [END swagger]
 basePath: "/"
 consumes:
 - "application/json"

--- a/endpoints/getting-started/swagger.yaml
+++ b/endpoints/getting-started/swagger.yaml
@@ -1,0 +1,105 @@
+swagger: "2.0"
+info:
+  description: "A simple Google Cloud Endpoints API example."
+  title: "Endpoints Example"
+  version: "1.0.0"
+host: "YOUR-PROJECT-ID.appspot.com"
+basePath: "/"
+consumes:
+- "application/json"
+produces:
+- "application/json"
+schemes:
+- "https"
+paths:
+  "/echo":
+    post:
+      description: "Echo back a given message."
+      operationId: "echo"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "Echo"
+          schema:
+            $ref: "#/definitions/echoMessage"
+      parameters:
+      - description: "Message to echo"
+        in: body
+        name: message
+        required: true
+        schema:
+          $ref: "#/definitions/echoMessage"
+  "/auth/info/googlejwt":
+    get:
+      description: "Returns the requests' authentication information."
+      operationId: "auth_info_google_jwt"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "Authenication info."
+          schema:
+            $ref: "#/definitions/authInfoResponse"
+      x-security:
+      - google_jwt:
+          audiences:
+          # This must match the "aud" field in the JWT. You can add multiple
+          # audiences to accept JWTs from multiple clients.
+          - "echo.endpoints.sample.google.com"
+  "/auth/info/googleidtoken":
+    get:
+      description: "Returns the requests' authentication information."
+      operationId: "authInfoGoogleIdToken"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "Authenication info."
+          schema:
+            $ref: "#/definitions/authInfoResponse"
+      x-security:
+      - google_id_token:
+          audiences:
+          # Your OAuth2 client's Client ID must be added here. You can add
+          # multiple client IDs to accept tokens from multiple clients.
+          - "YOUR-CLIENT-ID"
+definitions:
+  echoMessage:
+    properties:
+      message:
+        type: "string"
+  authInfoResponse:
+    properties:
+      id:
+        type: "string"
+      email:
+        type: "string"
+# This section requires all requests to any path to require an API key.
+security:
+- api_key: []
+securityDefinitions:
+  # This section configures basic authentication with an API key.
+  api_key:
+    type: "apiKey"
+    name: "key"
+    in: "query"
+  # This section configures authentication using Google API Service Accounts
+  # to sign a json web token. This is mostly used for server-to-server
+  # communication.
+  google_jwt:
+    authorizationUrl: ""
+    flow: "implicit"
+    type: "oauth2"
+    # This must match the 'iss' field in the JWT.
+    x-issuer: "jwt-client.endpoints.sample.google.com"
+    # Update this with your service account's email address.
+    x-jwks_uri: "https://www.googleapis.com/service_accounts/v1/jwk/YOUR-SERVICE-ACCOUNT-EMAIL"
+  # This section configures authentication using Google OAuth2 ID Tokens.
+  # ID Tokens can be obtained using OAuth2 clients, and can be used to access
+  # your API on behalf of a particular user.
+  google_id_token:
+    authorizationUrl: ""
+    flow: "implicit"
+    type: "oauth2"
+    x-issuer: "https://accounts.google.com"

--- a/spec/run-all.sh
+++ b/spec/run-all.sh
@@ -24,6 +24,7 @@ ruby --version
 for product in      \
 	bigquery    \
 	datastore   \
+	endpoints   \
 	language    \
 	logging     \
 	pubsub      \


### PR DESCRIPTION
We plan on cleaning up our docs for the various platforms and share this
sample throughout the various quickstart guides.

It no longer makes sense to have this under appgengine/flexible. Instead
it will live under endpoints/getting-started.

This also introduces how to deploy this sample using
GAE/GKE/GCE/GCE+Docker.