### PR TITLE
Updated region tag for list_bucket_contents_with_prefix

### DIFF
--- a/storage/files.rb
+++ b/storage/files.rb
@@ -30,7 +30,7 @@ def list_bucket_contents project_id:, bucket_name:
 end
 
 def list_bucket_contents_with_prefix project_id:, bucket_name:, prefix:
-  # [START list_bucket_contents]
+  # [START list_bucket_contents_with_prefix]
   # project_id  = "Your Google Cloud project ID"
   # bucket_name = "Your Google Cloud Storage bucket name"
   # prefix      = "Filter results to files whose names begin with this prefix"
@@ -45,7 +45,7 @@ def list_bucket_contents_with_prefix project_id:, bucket_name:, prefix:
   files.each do |file|
     puts file.name
   end
-  # [END list_bucket_contents]
+  # [END list_bucket_contents_with_prefix]
 end
 
 def upload_file project_id:, bucket_name:, local_file_path:,


### PR DESCRIPTION
**Context**
The _list_bucket_contents_with_prefix_ sample method currently uses the region tag for _list_bucket_contents_. I'm updating the region tag to reflect the sample. 

This duplication comes up on the following page: https://cloud.google.com/storage/docs/managing-buckets#storage-list-objects-ruby