### PR TITLE
Remove comments from app.yaml for SQL Flex sample

### DIFF
--- a/appengine/cloudsql/app.yaml
+++ b/appengine/cloudsql/app.yaml
@@ -21,16 +21,10 @@ env_variables:
   MYSQL_USER: [YOUR_USER]
   MYSQL_PASSWORD: [YOUR_PASSWORD]
   MYSQL_DATABASE: [YOUR_DATABASE]
-  # This path was printed to the console when you started the proxy, and is of
-  # the format: `/[DIR]/[YOUR_PROJECT_ID]:[YOUR_REGION]:[YOUR_INSTANCE_NAME]`
   MYSQL_SOCKET_PATH: /cloudsql/[YOUR_INSTANCE_CONNECTION_NAME]
 # [END env_variables]
 
 # [START cloudsql_settings]
 beta_settings:
-  # The instance connection name can be determined from this command:
-  # `gcloud sql instances describe [INSTANCE_NAME]` or by viewing the
-  # Instance details page in the Google Cloud Platform Console.
-  # It is of the format: `[YOUR_PROJECT_ID]:[YOUR_REGION]:[YOUR_INSTANCE_NAME]`
   cloud_sql_instances: [YOUR_INSTANCE_CONNECTION_NAME]
 # [END cloudsql_settings]


### PR DESCRIPTION
The comments were inside of doc region tags and appeared on the website.  The surrounding copy already describes the YAML configuration and placeholder variables so the comments were redundant.  Information about finding the value for [YOUR_INSTANCE_CONNECTION_NAME] is already present in this sample's README as well.

/cc @piaxc @frankyn 