### PR TITLE
Syntax updates to TaskList for embedded snippets

### DIFF
--- a/datastore/spec/tasks_spec.rb
+++ b/datastore/spec/tasks_spec.rb
@@ -14,6 +14,7 @@
 
 require_relative "../tasks"
 require "rspec"
+require "google/cloud/datastore"
 
 describe "Datastore task list" do
 
@@ -36,7 +37,7 @@ describe "Datastore task list" do
   it "creates a task" do
     desc = "Test description."
     allow($stdout).to receive(:puts)
-    id = new_task desc
+    id = add_task desc
     task = @datastore.find "Task", id
     expect(task.nil?).to be(false)
     expect(task["description"]).to eq(desc)

--- a/datastore/tasks.rb
+++ b/datastore/tasks.rb
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START build_service]
-require "google/cloud/datastore"
-
 def create_client project_id
+  # [START build_service]
+  require "google/cloud/datastore"
+
   @datastore = Google::Cloud::Datastore.new project: project_id
+  # [END build_service]
 end
-# [END build_service]
 
 # [START add_entity]
 def new_task description
@@ -48,14 +48,12 @@ end
 
 # [START retrieve_entities]
 def list_tasks
-  query = @datastore.query("Task").
-          order("created")
-
+  query = @datastore.query("Task").order("created")
   tasks = @datastore.run query
 
   tasks.each do |t|
-    puts t['description']
-    puts t['done'] ? "  Done" : "  Not Done"
+    puts t["description"]
+    puts t["done"] ? "  Done" : "  Not Done"
     puts "  ID: #{t.key.id}"
   end
 end

--- a/datastore/tasks.rb
+++ b/datastore/tasks.rb
@@ -32,6 +32,7 @@ def add_task description
   @datastore.save task
 
   puts task.key.id
+
   task.key.id
 end
 # [END add_entity]

--- a/datastore/tasks.rb
+++ b/datastore/tasks.rb
@@ -21,7 +21,7 @@ def create_client project_id
 end
 
 # [START add_entity]
-def new_task description
+def add_task description
   task = @datastore.entity "Task" do |t|
     t["description"] = description
     t["created"]     = Time.now
@@ -71,7 +71,7 @@ if __FILE__ == $0
   create_client ENV["GOOGLE_CLOUD_PROJECT"]
   case ARGV.shift
   when "new"
-    new_task ARGV.shift
+    add_task ARGV.shift
   when "done"
     mark_done ARGV.shift.to_i
   when "list"


### PR DESCRIPTION
 - Simplify snippet for "the call to create the authorized Cloud Datastore
   service object" to just a require statement and variable creation
 - Use double quotes consistently
 - Remove 2 unnecessary newlines to shorten sample showing listing tasks
 - Rename new_task to add_task for consistency with other samples and to make more clear