### PR TITLE
Update Endpoints samples:

### DIFF
--- a/endpoints/getting-started/app.yaml
+++ b/endpoints/getting-started/app.yaml
@@ -3,5 +3,7 @@ vm: true
 entrypoint: bundle exec ruby app.rb -p $PORT
 
 endpoints_api_service:
-  name: ENDPOINTS SERVICE-NAME # To be replaced.
-  config_id: ENDPOINTS CONFIG-ID # To be replaced.
+  # The following values are to be replaced by information from the output of
+  # 'gcloud service-management deploy openapi.yaml' command.
+  name: ENDPOINTS SERVICE-NAME
+  config_id: ENDPOINTS CONFIG-ID

--- a/endpoints/getting-started/app.yaml
+++ b/endpoints/getting-started/app.yaml
@@ -2,8 +2,6 @@ runtime: ruby
 vm: true
 entrypoint: bundle exec ruby app.rb -p $PORT
 
-beta_settings:
-  # Enable Google Cloud Endpoints API management.
-  use_endpoints_api_management: true
-  # Specify the Open API specification.
-  endpoints_swagger_spec_file: openapi.yaml
+endpoints_api_service:
+  name: ENDPOINTS SERVICE-NAME # To be replaced.
+  config_id: ENDPOINTS CONFIG-ID # To be replaced.

--- a/endpoints/getting-started/openapi.yaml
+++ b/endpoints/getting-started/openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: "A simple Google Cloud Endpoints API example."
   title: "Endpoints Example"
   version: "1.0.0"
-host: "YOUR-PROJECT-ID.appspot.com"
+host: "echo-api.endpoints.YOUR-PROJECT-ID.cloud.goog"
 # [END swagger]
 basePath: "/"
 consumes:


### PR DESCRIPTION
1. Change default service names to the new cloud.goog format.
2. Change app.yaml beta_settings to endpoints_api_service.