### PR TITLE
Update generate encryption key snippet

### DIFF
--- a/storage/files.rb
+++ b/storage/files.rb
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "base64"
-require "openssl"
-
 def list_bucket_contents project_id:, bucket_name:
   # [START list_bucket_contents]
   # project_id  = "Your Google Cloud project ID"
@@ -50,10 +47,15 @@ def list_bucket_contents_with_prefix project_id:, bucket_name:, prefix:
 end
 
 def generate_encryption_key_base64
+  # [START generate_encryption_key_base64]
+  require "base64"
+  require "openssl"
+
   encryption_key  = OpenSSL::Cipher.new("aes-256-cfb").encrypt.random_key
-  encoded_enc_key = Base64.encode64 encryption_key
+  encoded_enc_key = Base64.strict_encode64 encryption_key
 
   puts "Sample encryption key: #{encoded_enc_key}"
+  # [END generate_encryption_key_base64]
 end
 
 def upload_file project_id:, bucket_name:, local_file_path:,

--- a/storage/files.rb
+++ b/storage/files.rb
@@ -52,7 +52,7 @@ def generate_encryption_key_base64
   require "openssl"
 
   encryption_key  = OpenSSL::Cipher.new("aes-256-cfb").encrypt.random_key
-  encoded_enc_key = Base64.strict_encode64 encryption_key
+  encoded_enc_key = Base64.encode64 encryption_key
 
   puts "Sample encryption key: #{encoded_enc_key}"
   # [END generate_encryption_key_base64]

--- a/storage/spec/files_spec.rb
+++ b/storage/spec/files_spec.rb
@@ -71,12 +71,12 @@ describe "Google Cloud Storage files sample" do
   it "can generate a base64 encoded encryption key" do
     mock_cipher = double()
     mock_encrypt = double()
-    encryption_key_base64 = Base64.strict_encode64 @encryption_key
+    encryption_key_base64 = Base64.encode64 @encryption_key
 
     # Mock OpenSSL::Cipher
     expect(OpenSSL::Cipher).to receive(:new).with("aes-256-cfb").and_return(mock_cipher)
-    expect(mock_cipher).to receive(:encrypt).and_return(mock_encrypt)
-    expect(mock_encrypt).to receive(:random_key).and_return(@encryption_key)
+    expect(mock_cipher).to     receive(:encrypt).and_return(mock_encrypt)
+    expect(mock_encrypt).to    receive(:random_key).and_return(@encryption_key)
 
     expect {
       generate_encryption_key_base64

--- a/storage/spec/files_spec.rb
+++ b/storage/spec/files_spec.rb
@@ -68,6 +68,23 @@ describe "Google Cloud Storage files sample" do
   end
   attr_reader :captured_output
 
+  it "can generate a base64 encoded encryption key" do
+    mock_cipher = double()
+    mock_encrypt = double()
+    encryption_key_base64 = Base64.strict_encode64 @encryption_key
+
+    # Mock OpenSSL::Cipher
+    expect(OpenSSL::Cipher).to receive(:new).with("aes-256-cfb").and_return(mock_cipher)
+    expect(mock_cipher).to receive(:encrypt).and_return(mock_encrypt)
+    expect(mock_encrypt).to receive(:random_key).and_return(@encryption_key)
+
+    expect {
+      generate_encryption_key_base64
+    }.to output{
+      /Sample encryption key: #{encryption_key_base64}/
+    }.to_stdout
+  end
+
   it "can list files in a bucket" do
     upload @local_file_path, "file.txt"
     expect(@bucket.file "file.txt").not_to be nil


### PR DESCRIPTION
Updated method `generate_encryption_key_base64` to be a code sample. CloudSite will be using this section and the `require` statements should be within the method definition. 

Summary of Changes
* Changed Base64.encode64 to Base64.strict_encode64 because Base64.encode64 adds a newline character at the end of the encoded data.  
* Moved `require` statements within the method `generate_encryption_key_base64`
* Added a unit test that checks the method generates a base64 encoded encryption key.
* Added region tags around the sample.