### PR TITLE
KMS Sample Update PR

### DIFF
--- a/kms/README.md
+++ b/kms/README.md
@@ -54,6 +54,7 @@ Commands:
   disable_cryptokey_version           <key_ring> <crypto_key> <version> <location> Disable a cryptokey version
   restore_cryptokey_version           <key_ring> <crypto_key> <version> <location> Restore a cryptokey version
   destroy_cryptokey_version           <key_ring> <crypto_key> <version> <location> Destroy a cryptokey version
+  add_member_to_keyring_policy        <key_ring> <member> <role> <location> Add member to keyring IAM policy
   add_member_to_cryptokey_policy      <key_ring> <crypto_key> <member> <role> <location> Add member to cryptokey IAM policy
   remove_member_from_cryptokey_policy <key_ring> <crypto_key> <member> <role> <location> Remove member from cryptokey IAM policy
   get_keyring_policy                  <key_ring> <location> Get a keyring IAM policy

--- a/kms/README.md
+++ b/kms/README.md
@@ -50,6 +50,7 @@ Commands:
   encrypt_file                        <key_ring> <crypto_key> <location> <input_file> <output_file> Encrypt a file
   decrypt_file                        <key_ring> <crypto_key> <location> <input_file> <output_file> Decrypt a file
   create_cryptokey_version            <key_ring> <crypto_key> <location> Create a new cryptokey version
+  set_cryptokey_primary_version       <key_ring> <crypto_key> <verison> <location> Set a primary cryptokey version
   enable_cryptokey_version            <key_ring> <crypto_key> <version> <location> Enable a cryptokey version
   disable_cryptokey_version           <key_ring> <crypto_key> <version> <location> Disable a cryptokey version
   restore_cryptokey_version           <key_ring> <crypto_key> <version> <location> Restore a cryptokey version

--- a/kms/README.md
+++ b/kms/README.md
@@ -50,9 +50,10 @@ Commands:
   encrypt_file              <key_ring> <crypto_key> <location> <input_file> <output_file> Encrypt a file
   decrypt_file              <key_ring> <crypto_key> <location> <input_file> <output_file> Decrypt a file
   create_cryptokey_version  <key_ring> <crypto_key> <location> Create a new cryptokey version
+  enable_cryptokey_version  <key_ring> <crypto_key> <version> <location> Enable a cryptokey version
   disable_cryptokey_version <key_ring> <crypto_key> <version> <location> Disable a cryptokey version
   destroy_cryptokey_version <key_ring> <crypto_key> <version> <location> Destroy a cryptokey version
-  add_member                <key_ring> <crypto_key> <member> <role> <location> Add member to cryptokey IAM policy
+  add_member_to_policy      <key_ring> <crypto_key> <member> <role> <location> Add member to cryptokey IAM policy
   get_keyring_policy        <key_ring> <location> Get a keyring IAM policy
 
 Environment variables:

--- a/kms/README.md
+++ b/kms/README.md
@@ -45,17 +45,18 @@ These samples show how to use the [Google Cloud KMS API]
 Usage: bundle exec ruby kms.rb [command] [arguments]
 
 Commands:
-  create_keyring            <key_ring> <location> Create a new keyring
-  create_cryptokey          <key_ring> <crypto_key> <location> Create a new cryptokey
-  encrypt_file              <key_ring> <crypto_key> <location> <input_file> <output_file> Encrypt a file
-  decrypt_file              <key_ring> <crypto_key> <location> <input_file> <output_file> Decrypt a file
-  create_cryptokey_version  <key_ring> <crypto_key> <location> Create a new cryptokey version
-  enable_cryptokey_version  <key_ring> <crypto_key> <version> <location> Enable a cryptokey version
-  disable_cryptokey_version <key_ring> <crypto_key> <version> <location> Disable a cryptokey version
-  restore_cryptokey_version <key_ring> <crypto_key> <version> <location> Restore a cryptokey version
-  destroy_cryptokey_version <key_ring> <crypto_key> <version> <location> Destroy a cryptokey version
-  add_member_to_policy      <key_ring> <crypto_key> <member> <role> <location> Add member to cryptokey IAM policy
-  get_keyring_policy        <key_ring> <location> Get a keyring IAM policy
+  create_keyring                      <key_ring> <location> Create a new keyring
+  create_cryptokey                    <key_ring> <crypto_key> <location> Create a new cryptokey
+  encrypt_file                        <key_ring> <crypto_key> <location> <input_file> <output_file> Encrypt a file
+  decrypt_file                        <key_ring> <crypto_key> <location> <input_file> <output_file> Decrypt a file
+  create_cryptokey_version            <key_ring> <crypto_key> <location> Create a new cryptokey version
+  enable_cryptokey_version            <key_ring> <crypto_key> <version> <location> Enable a cryptokey version
+  disable_cryptokey_version           <key_ring> <crypto_key> <version> <location> Disable a cryptokey version
+  restore_cryptokey_version           <key_ring> <crypto_key> <version> <location> Restore a cryptokey version
+  destroy_cryptokey_version           <key_ring> <crypto_key> <version> <location> Destroy a cryptokey version
+  add_member_to_cryptokey_policy      <key_ring> <crypto_key> <member> <role> <location> Add member to cryptokey IAM policy
+  remove_member_from_cryptokey_policy <key_ring> <crypto_key> <member> <role> <location> Remove member from cryptokey IAM policy
+  get_keyring_policy                  <key_ring> <location> Get a keyring IAM policy
 
 Environment variables:
   GOOGLE_CLOUD_PROJECT must be set to your Google Cloud project ID

--- a/kms/README.md
+++ b/kms/README.md
@@ -52,6 +52,7 @@ Commands:
   create_cryptokey_version  <key_ring> <crypto_key> <location> Create a new cryptokey version
   enable_cryptokey_version  <key_ring> <crypto_key> <version> <location> Enable a cryptokey version
   disable_cryptokey_version <key_ring> <crypto_key> <version> <location> Disable a cryptokey version
+  restore_cryptokey_version <key_ring> <crypto_key> <version> <location> Restore a cryptokey version
   destroy_cryptokey_version <key_ring> <crypto_key> <version> <location> Destroy a cryptokey version
   add_member_to_policy      <key_ring> <crypto_key> <member> <role> <location> Add member to cryptokey IAM policy
   get_keyring_policy        <key_ring> <location> Get a keyring IAM policy

--- a/kms/kms.rb
+++ b/kms/kms.rb
@@ -50,7 +50,7 @@ $create_cryptokey = -> (project_id:, key_ring_id:, crypto_key:, location:) do
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the new key ring"
   # crypto_key  = "Name of the crypto key"
-  # location    = "The location of the new key ring"
+  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1beta1"
 
@@ -79,9 +79,9 @@ end
 $encrypt = -> (project_id:, key_ring_id:, crypto_key:, location:, input_file:, output_file:) do
   # [START kms_encrypt]
   # project_id  = "Your Google Cloud project ID"
-  # key_ring_id = "The ID of the new key ring"
+  # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
-  # location    = "The location of the new key ring"
+  # location    = "The location of the key ring"
   # input_file  = "File to encrypt"
   # output_file = "File name to use for encrypted input file"
 
@@ -115,9 +115,9 @@ end
 $decrypt = -> (project_id:, key_ring_id:, crypto_key:, location:, input_file:, output_file:) do
   # [START kms_decrypt]
   # project_id  = "Your Google Cloud project ID"
-  # key_ring_id = "The ID of the new key ring"
+  # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
-  # location    = "The location of the new key ring"
+  # location    = "The location of the key ring"
   # input_file  = "The path to an encrypted file"
   # output_file = "The path to write the decrypted file"
 
@@ -151,9 +151,9 @@ end
 $create_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, location:) do
   # [START kms_create_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
-  # key_ring_id = "The ID of the new key ring"
-  # crypto_key  = "Name of the crypto key"
-  # location    = "The location of the new key ring"
+  # key_ring_id = "The ID of the key ring"
+  # crypto_key  = "Name of the new crypto key"
+  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1beta1"
 
@@ -182,10 +182,10 @@ end
 $set_cryptokey_primary_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
   # [START kms_set_cryptokey_primary_version]
   # project_id  = "Your Google Cloud project ID"
-  # key_ring_id = "The ID of the new key ring"
+  # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # version     = "Version of the crypto key"
-  # location    = "The location of the new key ring"
+  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1beta1"
 
@@ -214,10 +214,10 @@ end
 $enable_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
   # [START kms_enable_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
-  # key_ring_id = "The ID of the new key ring"
+  # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # version     = "Version of the crypto key"
-  # location    = "The location of the new key ring"
+  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1beta1"
 
@@ -252,10 +252,10 @@ end
 $disable_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
   # [START kms_disable_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
-  # key_ring_id = "The ID of the new key ring"
+  # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # version     = "Version of the crypto key"
-  # location    = "The location of the new key ring"
+  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1beta1"
 
@@ -290,10 +290,10 @@ end
 $restore_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
   # [START kms_restore_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
-  # key_ring_id = "The ID of the new key ring"
+  # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # version     = "Version of the crypto key"
-  # location    = "The location of the new key ring"
+  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1beta1"
 
@@ -323,10 +323,10 @@ end
 $destroy_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
   # [START kms_destroy_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
-  # key_ring_id = "The ID of the new key ring"
+  # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # version     = "Version of the crypto key"
-  # location    = "The location of the new key ring"
+  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1beta1"
 
@@ -355,10 +355,10 @@ end
 $add_member_to_keyring_policy = -> (project_id:, key_ring_id:, member:, role:, location:) do
   # [START kms_add_member_to_keyring_policy]
   # project_id  = "Your Google Cloud project ID"
-  # key_ring_id = "The ID of the new key ring"
-  # member      = "Member to add to the crypto key policy"
+  # key_ring_id = "The ID of the key ring"
+  # member      = "Member to add to the key ring policy"
   # role        = "Role assignment for new member"
-  # location    = "The location of the new key ring"
+  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1beta1"
 
@@ -392,11 +392,11 @@ end
 $add_member_to_cryptokey_policy = -> (project_id:, key_ring_id:, crypto_key:, member:, role:, location:) do
   # [START kms_add_member_to_cryptokey_policy]
   # project_id  = "Your Google Cloud project ID"
-  # key_ring_id = "The ID of the new key ring"
+  # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # member      = "Member to add to the crypto key policy"
   # role        = "Role assignment for new member"
-  # location    = "The location of the new key ring"
+  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1beta1"
 
@@ -430,11 +430,11 @@ end
 $remove_member_from_cryptokey_policy = -> (project_id:, key_ring_id:, crypto_key:, member:, role:, location:) do
   # [START kms_remove_member_from_cryptokey_policy]
   # project_id  = "Your Google Cloud project ID"
-  # key_ring_id = "The ID of the new key ring"
+  # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
-  # member      = "Member to add to the crypto key policy"
-  # role        = "Role assignment for new member"
-  # location    = "The location of the new key ring"
+  # member      = "Member to remove to the crypto key policy"
+  # role        = "Role assignment for the member"
+  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1beta1"
 
@@ -471,8 +471,8 @@ end
 $get_keyring_policy = -> (project_id:, key_ring_id:, location:) do
   # [START kms_get_keyring_policy]
   # project_id  = "Your Google Cloud project ID"
-  # key_ring_id = "The ID of the new key ring"
-  # location    = "The location of the new key ring"
+  # key_ring_id = "The ID of the key ring"
+  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1beta1"
 

--- a/kms/kms.rb
+++ b/kms/kms.rb
@@ -255,6 +255,39 @@ $disable_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version
   # [END kms_disable_cryptokey_version]
 end
 
+$restore_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
+  # [START kms_restore_cryptokey_version]
+  # project_id  = "Your Google Cloud project ID"
+  # key_ring_id = "The ID of the new key ring"
+  # crypto_key  = "Name of the crypto key"
+  # version     = "Version of the crypto key"
+  # location    = "The location of the new key ring"
+
+  require "google/apis/cloudkms_v1beta1"
+
+  # Initialize the client and authenticate with the specified scope
+  Cloudkms = Google::Apis::CloudkmsV1beta1
+  kms_client = Cloudkms::CloudKMSService.new
+  kms_client.authorization = Google::Auth.get_application_default(
+    "https://www.googleapis.com/auth/cloud-platform"
+  )
+
+  # The resource name of the location associated with the key ring
+  resource = "projects/#{project_id}/locations/#{location}/" +
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
+             "cryptoKeyVersions/#{version}"
+
+  # Destroy specific version of the crypto key
+  kms_client.restore_crypto_key_version(
+    resource,
+    Cloudkms::RestoreCryptoKeyVersionRequest.new
+  )
+
+  puts "Restored version #{version} of #{crypto_key}"
+  # [END kms_restore_cryptokey_version]
+end
+
+
 $destroy_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
   # [START kms_destroy_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
@@ -417,6 +450,14 @@ def run_sample arguments
       version: arguments.shift,
       location: arguments.shift
     )
+  when "restore_cryptokey_version"
+    $restore_cryptokey_version.call(
+      project_id: project_id,
+      key_ring_id: arguments.shift,
+      crypto_key: arguments.shift,
+      version: arguments.shift,
+      location: arguments.shift
+    )
   when "destroy_cryptokey_version"
     $destroy_cryptokey_version.call(
       project_id: project_id,
@@ -452,6 +493,7 @@ Commands:
   create_cryptokey_version  <key_ring> <crypto_key> <location> Create a new cryptokey version
   enable_cryptokey_version  <key_ring> <crypto_key> <version> <location> Enable a cryptokey version
   disable_cryptokey_version <key_ring> <crypto_key> <version> <location> Disable a cryptokey version
+  restore_cryptokey_version <key_ring> <crypto_key> <version> <location> Restore a cryptokey version
   destroy_cryptokey_version <key_ring> <crypto_key> <version> <location> Destroy a cryptokey version
   add_member_to_policy      <key_ring> <crypto_key> <member> <role> <location> Add member to cryptokey IAM policy
   get_keyring_policy        <key_ring> <location> Get a keyring IAM policy

--- a/kms/kms.rb
+++ b/kms/kms.rb
@@ -455,7 +455,7 @@ $remove_member_from_cryptokey_policy = -> (project_id:, key_ring_id:, crypto_key
   # Remove a member to current bindings
   if policy.bindings
     policy.bindings.delete_if do |binding|
-      binding.role.include? role and binding.members.include? member
+      binding.role.include? role && binding.members.include? member
     end
   end
 

--- a/kms/kms.rb
+++ b/kms/kms.rb
@@ -455,7 +455,7 @@ $remove_member_from_cryptokey_policy = -> (project_id:, key_ring_id:, crypto_key
   # Remove a member to current bindings
   if policy.bindings
     policy.bindings.delete_if do |binding|
-      binding.role.include? role && binding.members.include? member
+      binding.role.include?(role) && binding.members.include?(member)
     end
   end
 

--- a/kms/kms.rb
+++ b/kms/kms.rb
@@ -179,6 +179,38 @@ $create_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, location
   # [END kms_create_cryptokey_version]
 end
 
+$set_cryptokey_primary_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
+  # [START kms_set_cryptokey_primary_version]
+  # project_id  = "Your Google Cloud project ID"
+  # key_ring_id = "The ID of the new key ring"
+  # crypto_key  = "Name of the crypto key"
+  # version     = "Version of the crypto key"
+  # location    = "The location of the new key ring"
+
+  require "google/apis/cloudkms_v1beta1"
+
+  # Initialize the client and authenticate with the specified scope
+  Cloudkms = Google::Apis::CloudkmsV1beta1
+  kms_client = Cloudkms::CloudKMSService.new
+  kms_client.authorization = Google::Auth.get_application_default(
+    "https://www.googleapis.com/auth/cloud-platform"
+  )
+
+  # The resource name of the location associated with the key ring crypto key
+  resource = "projects/#{project_id}/locations/#{location}/" +
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+
+  # Update the CryptoKey primary version
+  crypto_key_version = kms_client.update_project_location_key_ring_crypto_key_primary_version(
+      resource,
+      Cloudkms::UpdateCryptoKeyPrimaryVersionRequest.new(crypto_key_version_id: version)
+  )
+
+  puts "Set #{version} as primary version for crypto key " +
+       "#{crypto_key} in key ring #{key_ring_id}"
+  # [END kms_set_cryptokey_primary_version]
+end
+
 $enable_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
   # [START kms_enable_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
@@ -512,6 +544,14 @@ def run_sample arguments
       crypto_key: arguments.shift,
       location: arguments.shift
     )
+  when "set_cryptokey_primary_version"
+    $set_cryptokey_primary_version.call(
+      project_id: project_id,
+      key_ring_id: arguments.shift,
+      crypto_key: arguments.shift,
+      version: arguments.shift,
+      location: arguments.shift
+    )
   when "enable_cryptokey_version"
     $enable_cryptokey_version.call(
       project_id: project_id,
@@ -586,6 +626,7 @@ Commands:
   encrypt_file                        <key_ring> <crypto_key> <location> <input_file> <output_file> Encrypt a file
   decrypt_file                        <key_ring> <crypto_key> <location> <input_file> <output_file> Decrypt a file
   create_cryptokey_version            <key_ring> <crypto_key> <location> Create a new cryptokey version
+  set_cryptokey_primary_version       <key_ring> <crypto_key> <verison> <location> Set a primary cryptokey version
   enable_cryptokey_version            <key_ring> <crypto_key> <version> <location> Enable a cryptokey version
   disable_cryptokey_version           <key_ring> <crypto_key> <version> <location> Disable a cryptokey version
   restore_cryptokey_version           <key_ring> <crypto_key> <version> <location> Restore a cryptokey version

--- a/kms/kms.rb
+++ b/kms/kms.rb
@@ -207,7 +207,7 @@ $enable_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:
   # Set the primary version state as disabled for update
   crypto_key_version.state = "ENABLED"
 
-  # Disable the crypto key version
+  # Enable the crypto key version
   kms_client.patch_project_location_key_ring_crypto_key_crypto_key_version(
     resource,
     crypto_key_version, update_mask: "state"
@@ -277,7 +277,7 @@ $restore_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
              "cryptoKeyVersions/#{version}"
 
-  # Destroy specific version of the crypto key
+  # Restore specific version of the crypto key
   kms_client.restore_crypto_key_version(
     resource,
     Cloudkms::RestoreCryptoKeyVersionRequest.new

--- a/kms/kms.rb
+++ b/kms/kms.rb
@@ -94,7 +94,7 @@ $encrypt = -> (project_id:, key_ring_id:, crypto_key:, location:, input_file:, o
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring
+  # The resource name of the location associated with the key ring crypto key
   resource = "projects/#{project_id}/locations/#{location}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
@@ -130,7 +130,7 @@ $decrypt = -> (project_id:, key_ring_id:, crypto_key:, location:, input_file:, o
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring
+  # The resource name of the location associated with the key ring crypto key
   resource = "projects/#{project_id}/locations/#{location}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
@@ -164,7 +164,7 @@ $create_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, location
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring
+  # The resource name of the location associated with the key ring crypto key
   resource = "projects/#{project_id}/locations/#{location}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
@@ -196,7 +196,7 @@ $enable_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring
+  # The resource name of the location associated with the key ring crypto key version
   resource = "projects/#{project_id}/locations/#{location}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
              "cryptoKeyVersions/#{version}"
@@ -234,7 +234,7 @@ $disable_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring
+  # The resource name of the location associated with the key ring crypto key version
   resource = "projects/#{project_id}/locations/#{location}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
              "cryptoKeyVersions/#{version}"
@@ -272,7 +272,7 @@ $restore_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring
+  # The resource name of the location associated with the key ring crypto key version
   resource = "projects/#{project_id}/locations/#{location}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
              "cryptoKeyVersions/#{version}"
@@ -305,7 +305,7 @@ $destroy_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring
+  # The resource name of the location associated with the key ring crypto key version
   resource = "projects/#{project_id}/locations/#{location}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
              "cryptoKeyVersions/#{version}"
@@ -338,7 +338,7 @@ $add_member_to_cryptokey_policy = -> (project_id:, key_ring_id:, crypto_key:, me
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring
+  # The resource name of the location associated with the key ring crypto key
   resource = "projects/#{project_id}/locations/#{location}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
@@ -376,7 +376,7 @@ $remove_member_from_cryptokey_policy = -> (project_id:, key_ring_id:, crypto_key
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring
+  # The resource name of the location associated with the key ring crypto key
   resource = "projects/#{project_id}/locations/#{location}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 

--- a/kms/spec/kms_spec.rb
+++ b/kms/spec/kms_spec.rb
@@ -228,7 +228,7 @@ describe "Key Management Service" do
 
     if policy.bindings
       policy.bindings.delete_if do |binding|
-        binding.role.include? role && binding.members.include? member
+        binding.role.include?(role) && binding.members.include?(member)
       end
     end
 

--- a/kms/spec/kms_spec.rb
+++ b/kms/spec/kms_spec.rb
@@ -228,7 +228,7 @@ describe "Key Management Service" do
 
     if policy.bindings
       policy.bindings.delete_if do |binding|
-        binding.role.include? role and binding.members.include? member
+        binding.role.include? role && binding.members.include? member
       end
     end
 


### PR DESCRIPTION
This pull request updates the KMS samples with the following:

* [Bug] Incorrect comments used for certain samples
* [Bug] Updated test methods with 'test_blah' -> 'blah_test' 
* [Cleanup] Updated printing full path to a specific crypto key version to printing the version number only. (File: kms.rb Line: 177)
* [Updated] README to reflect added features
* [Feature] kms_remove_member_from_cryptokey_policy
* [Feature] kms_add_member_to_keyring_policy
* [Feature] kms_enable_cryptokey_version
* [Feature] kms_restore_cryptokey_version
* [Feature] kms_set_cryptokey_primary_version