### PR TITLE
added missing arg storage_file_path

### DIFF
--- a/storage/files.rb
+++ b/storage/files.rb
@@ -265,7 +265,7 @@ def run_sample arguments
     list_bucket_contents project_id:  ENV["GOOGLE_CLOUD_PROJECT"],
                          bucket_name: arguments.shift
   when "upload"
-    upload_file project_id:      ENV["GOOGLE_CLOUD_PROJECT"],
+    upload_file project_id:        ENV["GOOGLE_CLOUD_PROJECT"],
                 bucket_name:       arguments.shift,
                 local_file_path:   arguments.shift,
                 storage_file_path: arguments.shift

--- a/storage/files.rb
+++ b/storage/files.rb
@@ -267,7 +267,8 @@ def run_sample arguments
   when "upload"
     upload_file project_id:      ENV["GOOGLE_CLOUD_PROJECT"],
                 bucket_name:     arguments.shift,
-                local_file_path: arguments.shift
+                local_file_path: arguments.shift,
+                storage_file_path: arguments.shift
   when "enc_upload"
     upload_encrypted_file project_id:      ENV["GOOGLE_CLOUD_PROJECT"],
                           bucket_name:     arguments.shift,

--- a/storage/files.rb
+++ b/storage/files.rb
@@ -266,8 +266,8 @@ def run_sample arguments
                          bucket_name: arguments.shift
   when "upload"
     upload_file project_id:      ENV["GOOGLE_CLOUD_PROJECT"],
-                bucket_name:     arguments.shift,
-                local_file_path: arguments.shift,
+                bucket_name:       arguments.shift,
+                local_file_path:   arguments.shift,
                 storage_file_path: arguments.shift
   when "enc_upload"
     upload_encrypted_file project_id:      ENV["GOOGLE_CLOUD_PROJECT"],


### PR DESCRIPTION
This fixes the simple case in the Google Cloud Storage Ruby sample where a file is uploaded with a destination object name or storage path. The destination path arg was simply left off the CLI handling case for 'upload'.  Not urgent or critical or anything, but I ran into this (just now) in the process of familiarizing myself with how to work with buckets/files in Ruby, so I figure this might save someone else a few minutes.