### PR TITLE
[KMS] Fix quickstart kms spec

### DIFF
--- a/kms/spec/quickstart_spec.rb
+++ b/kms/spec/quickstart_spec.rb
@@ -36,11 +36,12 @@ describe "Key Management Service Quickstart" do
   end
 
   it "can list global key rings by name" do
-    test_project_id = ENV["GOOGLE_CLOUD_PROJECT"]
+    test_project_id  = ENV["GOOGLE_CLOUD_PROJECT"]
     test_key_ring_id = "list-#{test_project_id}-#{Time.now.to_i}"
-    test_parent = "projects/#{test_project_id}/locations/global"
+    test_parent      = "projects/#{test_project_id}/locations/global"
 
     test_key_ring = create_test_key_ring test_parent, test_key_ring_id
+
     expect(test_key_ring).not_to eq nil
     expect(test_key_ring.name).to match /#{test_key_ring_id}/
 
@@ -52,7 +53,7 @@ describe "Key Management Service Quickstart" do
         and_wrap_original do |m, *args|
       response = m.call test_parent
 
-      key_rings = response.key_rings
+      key_rings       = response.key_rings
       next_page_token = response.next_page_token
 
       while next_page_token
@@ -63,7 +64,7 @@ describe "Key Management Service Quickstart" do
         next_page_token = new_response.next_page_token
       end
 
-      double({key_rings: key_rings})
+      double key_rings: key_rings
     end
 
     expect {

--- a/kms/spec/quickstart_spec.rb
+++ b/kms/spec/quickstart_spec.rb
@@ -28,6 +28,15 @@ describe "Key Management Service Quickstart" do
                                             key_ring_id: key_ring_id
   end
 
+  def list_test_key_rings parent
+    client = Cloudkms::CloudKMSService.new
+    client.authorization = Google::Auth.get_application_default(
+      %[https://www.googleapis.com/auth/cloud-platform]
+    )
+
+    client.list_project_location_key_rings parent
+  end
+
   before :all do
     # Note: The quickstart sample defines a `Cloudkms` constant and causes
     #       "already initialized constant" warning because the spec defines the
@@ -37,13 +46,16 @@ describe "Key Management Service Quickstart" do
 
   it "can list global key rings by name" do
     test_project_id  = ENV["GOOGLE_CLOUD_PROJECT"]
-    test_key_ring_id = "list-#{test_project_id}-#{Time.now.to_i}"
+    test_key_ring_id = "a-keyring-list-#{test_project_id}"
     test_parent      = "projects/#{test_project_id}/locations/global"
+    test_key_rings   = list_test_key_rings(test_parent).key_rings
 
-    test_key_ring = create_test_key_ring test_parent, test_key_ring_id
+    if test_key_rings.nil?
+      test_key_ring = create_test_key_ring test_parent, test_key_ring_id
 
-    expect(test_key_ring).not_to eq nil
-    expect(test_key_ring.name).to match /#{test_key_ring_id}/
+      expect(test_key_ring).not_to  eq nil
+      expect(test_key_ring.name).to match /#{test_key_ring_id}/
+    end
 
     test_kms_client = Cloudkms::CloudKMSService.new
     expect(Cloudkms::CloudKMSService).to receive(:new).
@@ -51,26 +63,13 @@ describe "Key Management Service Quickstart" do
 
     expect(test_kms_client).to receive(:list_project_location_key_rings).
         and_wrap_original do |m, *args|
-      response = m.call test_parent
-
-      key_rings       = response.key_rings
-      next_page_token = response.next_page_token
-
-      while next_page_token
-        new_response = m.call test_parent, page_token: next_page_token
-
-        key_rings.concat new_response.key_rings
-
-        next_page_token = new_response.next_page_token
-      end
-
-      double key_rings: key_rings
+      m.call test_parent
     end
 
     expect {
       load File.expand_path("../quickstart.rb", __dir__)
     }.to output(
-      /#{test_key_ring.name}/
+      /list-#{test_project_id}/
     ).to_stdout
   end
 end

--- a/kms/spec/quickstart_spec.rb
+++ b/kms/spec/quickstart_spec.rb
@@ -54,7 +54,7 @@ describe "Key Management Service Quickstart" do
       test_key_ring = create_test_key_ring test_parent, test_key_ring_id
 
       expect(test_key_ring).not_to  eq nil
-      expect(test_key_ring.name).to match /#{test_key_ring_id}/
+      expect(test_key_ring.name).to include test_key_ring_id
     end
 
     test_kms_client = Cloudkms::CloudKMSService.new


### PR DESCRIPTION
The KMS quickstart lists all available key rings. The quickstart is tested by creating a new key ring, and the new key ring is expected to be included in the list of available key rings. 

The KMS quickstart test currently fails, because the list of key rings is long enough that the expected key ring is not included in the first page of available key rings.

In this PR, I added pagination support to the test, because the API doesn't support a delete key ring operation.

I'm open to other interpretations to solve this failure.