### PR TITLE
Remove explicit -p $PORT arguments from entrypoints

### DIFF
--- a/appengine/analytics/app.yaml
+++ b/appengine/analytics/app.yaml
@@ -15,7 +15,7 @@
 # [START app_yaml]
 runtime: ruby
 env: flex
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb
 
 env_variables:
   GA_TRACKING_ID: <your-tracking-id>

--- a/appengine/cloudsql/app.yaml
+++ b/appengine/cloudsql/app.yaml
@@ -14,7 +14,7 @@
 
 runtime: ruby
 env: flex
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb
 
 # [START env_variables]
 env_variables:

--- a/appengine/datastore/app.yaml
+++ b/appengine/datastore/app.yaml
@@ -15,5 +15,5 @@
 #[START all]
 runtime: ruby
 env: flex
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb
 #[END all]

--- a/appengine/endpoints/app.yaml
+++ b/appengine/endpoints/app.yaml
@@ -1,6 +1,6 @@
 runtime: ruby
 env: flex
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb
 
 beta_settings:
   # Enable Google Cloud Endpoints API management.

--- a/appengine/hello_world/app.yaml
+++ b/appengine/hello_world/app.yaml
@@ -15,5 +15,5 @@
 # [START app_yaml]
 runtime: ruby
 env: flex
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb
 # [END app_yaml]

--- a/appengine/mailgun/app.yaml
+++ b/appengine/mailgun/app.yaml
@@ -14,7 +14,7 @@
 
 runtime: ruby
 env: flex
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb
 
 # [START env_variables]
 env_variables:

--- a/appengine/memcache/app.yaml
+++ b/appengine/memcache/app.yaml
@@ -14,4 +14,4 @@
 
 runtime: ruby
 vm: true
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb

--- a/appengine/metadata_server/app.yaml
+++ b/appengine/metadata_server/app.yaml
@@ -14,4 +14,4 @@
 
 runtime: ruby
 env: flex
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb

--- a/appengine/pubsub/app.yaml
+++ b/appengine/pubsub/app.yaml
@@ -14,7 +14,7 @@
 
 runtime: ruby
 env: flex
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb
 # [START env_variables]
 env_variables:
     PUBSUB_TOPIC: <your-topic-name>

--- a/appengine/sendgrid/app.yaml
+++ b/appengine/sendgrid/app.yaml
@@ -14,7 +14,7 @@
 
 runtime: ruby
 env: flex
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb
 
 # [START env_variables]
 env_variables:

--- a/appengine/static_files/rails/app.yaml
+++ b/appengine/static_files/rails/app.yaml
@@ -13,4 +13,4 @@
 
 runtime: ruby
 env: flex
-entrypoint: bundle exec rails server -p $PORT
+entrypoint: bundle exec rails server

--- a/appengine/static_files/sinatra/app.yaml
+++ b/appengine/static_files/sinatra/app.yaml
@@ -13,4 +13,4 @@
 
 runtime: ruby
 env: flex
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb

--- a/appengine/storage/app.yaml
+++ b/appengine/storage/app.yaml
@@ -15,7 +15,7 @@
 # [START app_yaml]
 runtime: ruby
 env: flex
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb
 
 env_variables:
   GOOGLE_CLOUD_STORAGE_BUCKET: <your-bucket-name>

--- a/appengine/twilio/app.yaml
+++ b/appengine/twilio/app.yaml
@@ -14,7 +14,7 @@
 
 runtime: ruby
 env: flex
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb
 
 # [START env_variables]
 env_variables:

--- a/endpoints/getting-started/app.yaml
+++ b/endpoints/getting-started/app.yaml
@@ -1,6 +1,6 @@
 runtime: ruby
 vm: true
-entrypoint: bundle exec ruby app.rb -p $PORT
+entrypoint: bundle exec ruby app.rb
 
 endpoints_api_service:
   # The following values are to be replaced by information from the output of


### PR DESCRIPTION
Remove `-p $PORT` from every Flex entrypoint.

----

Both Rails and Sinatra respect $PORT and will use it when set.

$PORT is set by the Flex environment so no custom port is needed.

#### Rails

```
$ rails s
WARNING: Nokogiri was built against LibXML version 2.9.2, but has dynamically loaded 2.9.4
=> Booting Puma
=> Rails 5.0.2 application starting in development on http://localhost:3000

$ PORT=1234 rails s
WARNING: Nokogiri was built against LibXML version 2.9.2, but has dynamically loaded 2.9.4
=> Booting Puma
=> Rails 5.0.2 application starting in development on http://localhost:1234
```

#### Sinatra

```
$ ruby app.rb 
== Sinatra (v1.4.8) has taken the stage on 4567 for development with backup from Puma
Puma starting in single mode...
* Version 3.8.2 (ruby 2.3.1-p112), codename: Sassy Salamander
* Min threads: 0, max threads: 16
* Environment: development
* Listening on tcp://localhost:4567

$ PORT=1234 ruby app.rb 
== Sinatra (v1.4.8) has taken the stage on 1234 for development with backup from Puma
Puma starting in single mode...
* Version 3.8.2 (ruby 2.3.1-p112), codename: Sassy Salamander
* Min threads: 0, max threads: 16
* Environment: development
* Listening on tcp://localhost:1234
```