### PR TITLE
Update App Engine Memcached README to note Managed VMs (not Flexible Environment)

### DIFF
--- a/appengine/memcache/README.md
+++ b/appengine/memcache/README.md
@@ -1,7 +1,15 @@
-# Memcached sample for Google App Engine flexible environment
+# Memcached sample for Google App Engine Managed VMs
 
 This sample demonstrates accessing Memcached from Ruby on
-[Google App Engine flexible environment](https://cloud.google.com/appengine/docs/flexible/).
+[Google App Engine Managed VMs](https://cloud.google.com/appengine/docs/flexible/ruby/upgrading).
+
+> ##### **Warning:** This sample uses the Managed VMs beta environment (applications deployed with `vm:true`), which is deprecated and will be decomissioned.
+> The Memcache service is currently not available for the App Engine flexible environment.
+> An alpha version of the memcache service will be available shortly. If you would like to be
+> notified when the service is available, fill out this
+> [early access form](https://goo.gl/forms/kklwZTrkicAKaHrD3).
+
+See [Memcached Service](https://cloud.google.com/appengine/docs/flexible/ruby/upgrading#memcache_service) for more information.
 
 ## Running locally
 


### PR DESCRIPTION
The Memcache service is currently not available for the App Engine flexible environment.

Add note linking to more information as well as pointing this out.

The sample uses Managed VMs which is deprecated and will be decommissioned.

Related #162 