### PR TITLE
Use "env: flex" for the Endpoints sample.

### DIFF
--- a/endpoints/getting-started/app.yaml
+++ b/endpoints/getting-started/app.yaml
@@ -1,5 +1,5 @@
 runtime: ruby
-vm: true
+env: flex
 entrypoint: bundle exec ruby app.rb
 
 endpoints_api_service:


### PR DESCRIPTION
The old "vm: true" is deprecated and won't deploy.