### PR TITLE
Add openapi-appengine.yaml file for App Engine deployments.

### DIFF
--- a/endpoints/getting-started/openapi-appengine.yaml
+++ b/endpoints/getting-started/openapi-appengine.yaml
@@ -4,7 +4,7 @@ info:
   description: "A simple Google Cloud Endpoints API example."
   title: "Endpoints Example"
   version: "1.0.0"
-host: "echo-api.endpoints.YOUR-PROJECT-ID.cloud.goog"
+host: "YOUR-PROJECT-ID.appspot.com"
 # [END swagger]
 basePath: "/"
 consumes:


### PR DESCRIPTION
After conversation with the Endpoints team, this was the most effective solution we came up with to guide users through setting up Endpoints on App Engine. Having users uncomment code proved to be difficult. If you have another idea that could work better, please let me know. Otherwise, this will have to do.