### PR TITLE
Update Spanner Samples based on comments

### DIFF
--- a/spanner/spanner_samples.rb
+++ b/spanner/spanner_samples.rb
@@ -67,8 +67,8 @@ def insert_data project_id:, instance_id:, database_id:
       { SingerId: 5, FirstName: "David",    LastName: "Lomond"   }
     ]
     c.insert "Albums", [
-      { SingerId: 1, AlbumId: 1, AlbumTitle: "Go, Go, Go"              },
-      { SingerId: 1, AlbumId: 2, AlbumTitle: "Total Junk"              },
+      { SingerId: 1, AlbumId: 1, AlbumTitle: "Total Junk"              },
+      { SingerId: 1, AlbumId: 2, AlbumTitle: "Go, Go, Go"              },
       { SingerId: 2, AlbumId: 1, AlbumTitle: "Green"                   },
       { SingerId: 2, AlbumId: 2, AlbumTitle: "Forever Hold your Peace" },
       { SingerId: 2, AlbumId: 3, AlbumTitle: "Terrified"               }

--- a/spanner/spanner_samples.rb
+++ b/spanner/spanner_samples.rb
@@ -70,7 +70,7 @@ def insert_data project_id:, instance_id:, database_id:
       { SingerId: 1, AlbumId: 1, AlbumTitle: "Total Junk"              },
       { SingerId: 1, AlbumId: 2, AlbumTitle: "Go, Go, Go"              },
       { SingerId: 2, AlbumId: 1, AlbumTitle: "Green"                   },
-      { SingerId: 2, AlbumId: 2, AlbumTitle: "Forever Hold your Peace" },
+      { SingerId: 2, AlbumId: 2, AlbumTitle: "Forever Hold Your Peace" },
       { SingerId: 2, AlbumId: 3, AlbumTitle: "Terrified"               }
     ]
   end

--- a/spanner/spanner_samples.rb
+++ b/spanner/spanner_samples.rb
@@ -330,6 +330,12 @@ def read_only_transaction project_id:, instance_id:, database_id:
   client  = spanner.client instance_id, database_id
 
   client.snapshot do |snapshot|
+    snapshot.execute("SELECT SingerId, AlbumId, AlbumTitle FROM Albums").rows.each do |row|
+      puts "#{row[:AlbumId]} #{row[:AlbumTitle]} #{row[:SingerId]}"
+    end
+
+    # Even if changes occur in-between the reads, the transaction ensures that
+    # both return the same data.
     snapshot.read("Albums", [:AlbumId, :AlbumTitle, :SingerId]).rows.each do |row|
       puts "#{row[:AlbumId]} #{row[:AlbumTitle]} #{row[:SingerId]}"
     end

--- a/spanner/spec/spanner_samples_spec.rb
+++ b/spanner/spec/spanner_samples_spec.rb
@@ -116,8 +116,8 @@ describe "Google Cloud Spanner API samples" do
                  database_id: database.database_id
     end
 
-    expect(captured_output).to include "1 1 Go, Go, Go"
-    expect(captured_output).to include "1 2 Total Junk"
+    expect(captured_output).to include "1 1 Total Junk"
+    expect(captured_output).to include "1 2 Go, Go, Go"
     expect(captured_output).to include "2 1 Green"
     expect(captured_output).to include "2 2 Forever Hold your Peace"
     expect(captured_output).to include "2 3 Terrified"
@@ -138,8 +138,8 @@ describe "Google Cloud Spanner API samples" do
                 database_id: database.database_id
     end
 
-    expect(captured_output).to include "1 1 Go, Go, Go"
-    expect(captured_output).to include "1 2 Total Junk"
+    expect(captured_output).to include "1 1 Total Junk"
+    expect(captured_output).to include "1 2 Go, Go, Go"
     expect(captured_output).to include "2 1 Green"
     expect(captured_output).to include "2 2 Forever Hold your Peace"
     expect(captured_output).to include "2 3 Terrified"
@@ -226,7 +226,7 @@ describe "Google Cloud Spanner API samples" do
 
     albums = client.execute("SELECT * FROM Albums").rows.map &:to_h
     expect(albums).to include(
-      { SingerId: 1, AlbumId: 1, AlbumTitle: "Go, Go, Go", MarketingBudget: nil }
+      { SingerId: 1, AlbumId: 1, AlbumTitle: "Total Junk", MarketingBudget: nil }
     )
 
     capture do
@@ -239,7 +239,7 @@ describe "Google Cloud Spanner API samples" do
 
     albums = client.execute("SELECT * FROM Albums").rows.map &:to_h
     expect(albums).to include(
-      { SingerId: 1, AlbumId: 1, AlbumTitle: "Go, Go, Go", MarketingBudget: 100_000 }
+      { SingerId: 1, AlbumId: 1, AlbumTitle: "Total Junk", MarketingBudget: 100_000 }
     )
   end
 
@@ -368,7 +368,7 @@ describe "Google Cloud Spanner API samples" do
                             database_id: database.database_id
     end
 
-    expect(captured_output).to include "1 Go, Go, Go"
+    expect(captured_output).to include "2 Go, Go, Go"
     expect(captured_output).to include "2 Forever Hold your Peace"
   end
 
@@ -397,7 +397,7 @@ describe "Google Cloud Spanner API samples" do
                            database_id: database.database_id
     end
 
-    expect(captured_output).to include "1 Go, Go, Go"
+    expect(captured_output).to include "1 Total Junk"
     expect(captured_output).to include "2 Forever Hold your Peace"
   end
 
@@ -416,7 +416,6 @@ describe "Google Cloud Spanner API samples" do
                database_id: database.database_id
 
     # Add index on Albums(AlbumTitle) (re-use create_index to add)
-    # XXX create_storing_index is not yet tested, but is required by this test
     create_storing_index project_id:  @project_id,
                          instance_id: @instance.instance_id,
                          database_id: database.database_id
@@ -427,7 +426,7 @@ describe "Google Cloud Spanner API samples" do
                                    database_id: database.database_id
     end
 
-    expect(captured_output).to include "1 Go, Go, Go"
+    expect(captured_output).to include "1 Total Junk"
     expect(captured_output).to include "2 Forever Hold your Peace"
   end
 
@@ -446,7 +445,7 @@ describe "Google Cloud Spanner API samples" do
                             database_id: database.database_id
     end
 
-    expect(captured_output).to include "1 Go, Go, Go 1"
+    expect(captured_output).to include "1 Total Junk 1"
     expect(captured_output).to include "2 Forever Hold your Peace 2"
   end
 end

--- a/spanner/spec/spanner_samples_spec.rb
+++ b/spanner/spec/spanner_samples_spec.rb
@@ -119,7 +119,7 @@ describe "Google Cloud Spanner API samples" do
     expect(captured_output).to include "1 1 Total Junk"
     expect(captured_output).to include "1 2 Go, Go, Go"
     expect(captured_output).to include "2 1 Green"
-    expect(captured_output).to include "2 2 Forever Hold your Peace"
+    expect(captured_output).to include "2 2 Forever Hold Your Peace"
     expect(captured_output).to include "2 3 Terrified"
   end
 
@@ -141,7 +141,7 @@ describe "Google Cloud Spanner API samples" do
     expect(captured_output).to include "1 1 Total Junk"
     expect(captured_output).to include "1 2 Go, Go, Go"
     expect(captured_output).to include "2 1 Green"
-    expect(captured_output).to include "2 2 Forever Hold your Peace"
+    expect(captured_output).to include "2 2 Forever Hold Your Peace"
     expect(captured_output).to include "2 3 Terrified"
   end
 
@@ -369,7 +369,7 @@ describe "Google Cloud Spanner API samples" do
     end
 
     expect(captured_output).to include "2 Go, Go, Go"
-    expect(captured_output).to include "2 Forever Hold your Peace"
+    expect(captured_output).to include "2 Forever Hold Your Peace"
   end
 
   example "read data with index" do
@@ -398,7 +398,7 @@ describe "Google Cloud Spanner API samples" do
     end
 
     expect(captured_output).to include "1 Total Junk"
-    expect(captured_output).to include "2 Forever Hold your Peace"
+    expect(captured_output).to include "2 Forever Hold Your Peace"
   end
 
   example "read data with storing index" do
@@ -427,7 +427,7 @@ describe "Google Cloud Spanner API samples" do
     end
 
     expect(captured_output).to include "1 Total Junk"
-    expect(captured_output).to include "2 Forever Hold your Peace"
+    expect(captured_output).to include "2 Forever Hold Your Peace"
   end
 
   example "read only transaction" do
@@ -446,6 +446,6 @@ describe "Google Cloud Spanner API samples" do
     end
 
     expect(captured_output).to include "1 Total Junk 1"
-    expect(captured_output).to include "2 Forever Hold your Peace 2"
+    expect(captured_output).to include "2 Forever Hold Your Peace 2"
   end
 end


### PR DESCRIPTION
This PR:
* reorder Albums "Go, Go, Go" and "Total Junk" to be consistent with documentation.
* Updates read_only_transaction sample to include call to `Client#execute` to be consistent with other language samples. In case there's a question, the reason why there's no KeySet all: true similar to other languages is because it's set [automatically](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/39b2a50dc10099d0d5893a1141996ce005d774f7/google-cloud-spanner/lib/google/cloud/spanner/service.rb#L360) by the client library.