### PR TITLE
KMS: Make the samples consistent with the other languages.

### DIFF
--- a/kms/kms.rb
+++ b/kms/kms.rb
@@ -510,113 +510,113 @@ def run_sample arguments
   case command
   when "create_key_ring"
     $create_key_ring.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift
     )
   when "create_crypto_key"
     $create_crypto_key.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift,
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift,
       crypto_key_id: arguments.shift
     )
   when "encrypt_file"
     $encrypt.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift,
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift,
       crypto_key_id: arguments.shift,
-      input_file: arguments.shift,
-      output_file: arguments.shift
+      input_file:    arguments.shift,
+      output_file:   arguments.shift
     )
   when "decrypt_file"
     $decrypt.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift,
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift,
       crypto_key_id: arguments.shift,
-      input_file: arguments.shift,
-      output_file: arguments.shift
+      input_file:    arguments.shift,
+      output_file:   arguments.shift
     )
   when "create_crypto_key_version"
     $create_crypto_key_version.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift,
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift,
       crypto_key_id: arguments.shift
     )
   when "set_crypto_key_primary_version"
     $set_crypto_key_primary_version.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift,
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift,
       crypto_key_id: arguments.shift,
-      version_id: arguments.shift
+      version_id:    arguments.shift
     )
   when "enable_crypto_key_version"
     $enable_crypto_key_version.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift,
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift,
       crypto_key_id: arguments.shift,
-      version_id: arguments.shift
+      version_id:    arguments.shift
     )
   when "disable_crypto_key_version"
     $disable_crypto_key_version.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift,
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift,
       crypto_key_id: arguments.shift,
-      version_id: arguments.shift
+      version_id:    arguments.shift
     )
   when "restore_crypto_key_version"
     $restore_crypto_key_version.call(
-      project_id: project_id,
-      key_ring_id: arguments.shift,
+      project_id:    project_id,
+      key_ring_id:   arguments.shift,
       crypto_key_id: arguments.shift,
-      version_id: arguments.shift,
-      location_id: arguments.shift,
+      version_id:    arguments.shift,
+      location_id:   arguments.shift,
     )
   when "destroy_crypto_key_version"
     $destroy_crypto_key_version.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift,
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift,
       crypto_key_id: arguments.shift,
-      version_id: arguments.shift
+      version_id:    arguments.shift
     )
   when "add_member_to_key_ring_policy"
     $add_member_to_key_ring_policy.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift,
-      member: arguments.shift,
-      role: arguments.shift
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift,
+      member:        arguments.shift,
+      role:          arguments.shift
     )
   when "add_member_to_crypto_key_policy"
     $add_member_to_crypto_key_policy.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift,
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift,
       crypto_key_id: arguments.shift,
-      member: arguments.shift,
-      role: arguments.shift
+      member:        arguments.shift,
+      role:          arguments.shift
     )
   when "remove_member_from_crypto_key_policy"
     $remove_member_from_crypto_key_policy.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift,
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift,
       crypto_key_id: arguments.shift,
-      member: arguments.shift,
-      role: arguments.shift
+      member:        arguments.shift,
+      role:          arguments.shift
     )
   when "get_key_ring_policy"
     $get_key_ring_policy.call(
-      project_id: project_id,
-      location_id: arguments.shift,
-      key_ring_id: arguments.shift
+      project_id:    project_id,
+      location_id:   arguments.shift,
+      key_ring_id:   arguments.shift
     )
   else
     puts <<-usage

--- a/kms/kms.rb
+++ b/kms/kms.rb
@@ -76,14 +76,14 @@ $create_crypto_key = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:
   # [END kms_create_cryptokey]
 end
 
-$encrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, input_file:, output_file:) do
+$encrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, plaintext_file:, ciphertext_file:) do
   # [START kms_encrypt]
-  # project_id    = "Your Google Cloud project ID"
-  # location_id   = "The location of the key ring"
-  # key_ring_id   = "The ID of the key ring"
-  # crypto_key_id = "The ID of the crypto key"
-  # input_file    = "File to encrypt"
-  # output_file   = "File name to use for encrypted input file"
+  # project_id      = "Your Google Cloud project ID"
+  # location_id     = "The location of the key ring"
+  # key_ring_id     = "The ID of the key ring"
+  # crypto_key_id   = "The ID of the crypto key"
+  # plaintext_file  = "File to encrypt"
+  # ciphertext_file = "File to store encrypted input data"
 
   require "google/apis/cloudkms_v1"
 
@@ -98,28 +98,29 @@ $encrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, input_fi
   resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
-  # Use the KMS API to encrypt the text
-  plain_text = File.read input_file
+  # Read the secret data from the file
+  plaintext = File.read plaintext_file
 
-  request = Cloudkms::EncryptRequest.new plaintext: plain_text
+  request = Cloudkms::EncryptRequest.new plaintext: plaintext
 
+  # Use the KMS API to encrypt the data
   response = kms_client.encrypt_crypto_key resource, request
 
-  # Write the encrypted text to a file
-  File.write output_file, response.ciphertext
+  # Write the encrypted text to the output file
+  File.write ciphertext_file, response.ciphertext
 
-  puts "Saved encrypted #{input_file} as #{output_file}"
+  puts "Saved encrypted #{plaintext_file} as #{ciphertext_file}"
   # [END kms_encrypt]
 end
 
-$decrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, input_file:, output_file:) do
+$decrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, ciphertext_file:, plaintext_file:) do
   # [START kms_decrypt]
   # project_id    = "Your Google Cloud project ID"
   # location_id   = "The location of the key ring"
   # key_ring_id   = "The ID of the key ring"
   # crypto_key_id = "The ID of the crypto key"
-  # input_file    = "The path to an encrypted file"
-  # output_file   = "The path to write the decrypted file"
+  # ciphertext_file = "File to decrypt"
+  # plaintext_file  = "File to store decrypted data"
 
   require "google/apis/cloudkms_v1"
 
@@ -134,17 +135,18 @@ $decrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, input_fi
   resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
-  # Use the KMS API to decrypt the text
-  encrypted_text = File.read input_file
+  # Read the encrypted data from the file
+  ciphertext = File.read ciphertext_file
 
-  request = Cloudkms::DecryptRequest.new ciphertext: encrypted_text
+  request = Cloudkms::DecryptRequest.new ciphertext: ciphertext
 
+  # Use the KMS API to decrypt the data
   response = kms_client.decrypt_crypto_key resource, request
 
-  # Write the decrypted text to a file
-  File.write output_file, response.plaintext
+  # Write the decrypted text to the output file
+  File.write plaintext_file, response.plaintext
 
-  puts "Saved decrypted #{input_file} as #{output_file}"
+  puts "Saved decrypted #{ciphertext_file} as #{plaintext_file}"
   # [END kms_decrypt]
 end
 

--- a/kms/kms.rb
+++ b/kms/kms.rb
@@ -45,12 +45,12 @@ $create_key_ring = -> (project_id:, location_id:, key_ring_id:) do
   # [END kms_create_keyring]
 end
 
-$create_crypto_key = -> (project_id:, location_id:, key_ring_id:, crypto_key:) do
+$create_crypto_key = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:) do
   # [START kms_create_cryptokey]
-  # project_id  = "Your Google Cloud project ID"
-  # location_id = "The location of the key ring"
-  # key_ring_id = "The ID of the new key ring"
-  # crypto_key  = "Name of the crypto key"
+  # project_id    = "Your Google Cloud project ID"
+  # location_id   = "The location of the key ring"
+  # key_ring_id   = "The ID of the key ring"
+  # crypto_key_id = "The ID of the new crypto key"
 
   require "google/apis/cloudkms_v1"
 
@@ -61,29 +61,29 @@ $create_crypto_key = -> (project_id:, location_id:, key_ring_id:, crypto_key:) d
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring
+  # The resource name of the key ring
   resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}"
 
-  # Create a crypto key for your project key ring
+  # Create a crypto key in the key ring
   new_crypto_key = kms_client.create_project_location_key_ring_crypto_key(
     resource,
     Cloudkms::CryptoKey.new(purpose: "ENCRYPT_DECRYPT"),
-    crypto_key_id: crypto_key
+    crypto_key_id: crypto_key_id
   )
 
-  puts "Created crypto key #{crypto_key}"
+  puts "Created crypto key #{crypto_key_id}"
   # [END kms_create_cryptokey]
 end
 
-$encrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key:, input_file:, output_file:) do
+$encrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, input_file:, output_file:) do
   # [START kms_encrypt]
-  # project_id  = "Your Google Cloud project ID"
-  # location_id = "The location of the key ring"
-  # key_ring_id = "The ID of the key ring"
-  # crypto_key  = "Name of the crypto key"
-  # input_file  = "File to encrypt"
-  # output_file = "File name to use for encrypted input file"
+  # project_id    = "Your Google Cloud project ID"
+  # location_id   = "The location of the key ring"
+  # key_ring_id   = "The ID of the key ring"
+  # crypto_key_id = "The ID of the crypto key"
+  # input_file    = "File to encrypt"
+  # output_file   = "File name to use for encrypted input file"
 
   require "google/apis/cloudkms_v1"
 
@@ -94,9 +94,9 @@ $encrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key:, input_file:
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring crypto key
+  # The resource name of the crypto key
   resource = "projects/#{project_id}/locations/#{location_id}/" +
-             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
   # Use the KMS API to encrypt the text
   plain_text = File.read input_file
@@ -112,14 +112,14 @@ $encrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key:, input_file:
   # [END kms_encrypt]
 end
 
-$decrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key:, input_file:, output_file:) do
+$decrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, input_file:, output_file:) do
   # [START kms_decrypt]
-  # project_id  = "Your Google Cloud project ID"
-  # location_id = "The location of the key ring"
-  # key_ring_id = "The ID of the key ring"
-  # crypto_key  = "Name of the crypto key"
-  # input_file  = "The path to an encrypted file"
-  # output_file = "The path to write the decrypted file"
+  # project_id    = "Your Google Cloud project ID"
+  # location_id   = "The location of the key ring"
+  # key_ring_id   = "The ID of the key ring"
+  # crypto_key_id = "The ID of the crypto key"
+  # input_file    = "The path to an encrypted file"
+  # output_file   = "The path to write the decrypted file"
 
   require "google/apis/cloudkms_v1"
 
@@ -130,9 +130,9 @@ $decrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key:, input_file:
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring crypto key
+  # The resource name of the crypto key
   resource = "projects/#{project_id}/locations/#{location_id}/" +
-             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
   # Use the KMS API to decrypt the text
   encrypted_text = File.read input_file
@@ -148,12 +148,12 @@ $decrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key:, input_file:
   # [END kms_decrypt]
 end
 
-$create_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto_key:) do
+$create_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:) do
   # [START kms_create_cryptokey_version]
-  # project_id  = "Your Google Cloud project ID"
-  # location_id = "The location of the key ring"
-  # key_ring_id = "The ID of the key ring"
-  # crypto_key  = "Name of the new crypto key"
+  # project_id    = "Your Google Cloud project ID"
+  # location_id   = "The location of the key ring"
+  # key_ring_id   = "The ID of the key ring"
+  # crypto_key_id = "The ID of the crypto key"
 
   require "google/apis/cloudkms_v1"
 
@@ -164,28 +164,28 @@ $create_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring crypto key
+  # The resource name of the crypto key
   resource = "projects/#{project_id}/locations/#{location_id}/" +
-             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
-  # Create the crypto key version for your project
+  # Create a new version in the crypto key
   crypto_key_version = kms_client.create_project_location_key_ring_crypto_key_crypto_key_version(
       resource,
       Cloudkms::CryptoKey.new(purpose: "ENCRYPT_DECRYPT")
   )
 
   puts "Created version #{crypto_key_version.name} for key " +
-       "#{crypto_key} in key ring #{key_ring_id}"
+       "#{crypto_key_id} in key ring #{key_ring_id}"
   # [END kms_create_cryptokey_version]
 end
 
-$set_crypto_key_primary_version = -> (project_id:, location_id:, key_ring_id:, crypto_key:, version:) do
+$set_crypto_key_primary_version = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, version_id:) do
   # [START kms_set_cryptokey_primary_version]
-  # project_id  = "Your Google Cloud project ID"
-  # location_id = "The location of the key ring"
-  # key_ring_id = "The ID of the key ring"
-  # crypto_key  = "Name of the crypto key"
-  # version     = "Version of the crypto key"
+  # project_id    = "Your Google Cloud project ID"
+  # location_id   = "The location of the key ring"
+  # key_ring_id   = "The ID of the key ring"
+  # crypto_key_id = "The ID of the crypto key"
+  # version_id    = "Version of the crypto key"
 
   require "google/apis/cloudkms_v1"
 
@@ -196,28 +196,28 @@ $set_crypto_key_primary_version = -> (project_id:, location_id:, key_ring_id:, c
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring crypto key
+  # The resource name of the crypto key
   resource = "projects/#{project_id}/locations/#{location_id}/" +
-             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
   # Update the CryptoKey primary version
   crypto_key_version = kms_client.update_project_location_key_ring_crypto_key_primary_version(
       resource,
-      Cloudkms::UpdateCryptoKeyPrimaryVersionRequest.new(crypto_key_version_id: version)
+      Cloudkms::UpdateCryptoKeyPrimaryVersionRequest.new(crypto_key_version_id: version_id)
   )
 
-  puts "Set #{version} as primary version for crypto key " +
-       "#{crypto_key} in key ring #{key_ring_id}"
+  puts "Set #{version_id} as primary version for crypto key " +
+       "#{crypto_key_id} in key ring #{key_ring_id}"
   # [END kms_set_cryptokey_primary_version]
 end
 
-$enable_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto_key:, version:) do
+$enable_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, version_id:) do
   # [START kms_enable_cryptokey_version]
-  # project_id  = "Your Google Cloud project ID"
-  # location_id = "The location of the key ring"
-  # key_ring_id = "The ID of the key ring"
-  # crypto_key  = "Name of the crypto key"
-  # version     = "Version of the crypto key"
+  # project_id    = "Your Google Cloud project ID"
+  # location_id   = "The location of the key ring"
+  # key_ring_id   = "The ID of the key ring"
+  # crypto_key_id = "The ID of the crypto key"
+  # version_id    = "Version of the crypto key"
 
   require "google/apis/cloudkms_v1"
 
@@ -228,10 +228,10 @@ $enable_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring crypto key version
+  # The resource name of the crypto key version
   resource = "projects/#{project_id}/locations/#{location_id}/" +
-             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
-             "cryptoKeyVersions/#{version}"
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}/" +
+             "cryptoKeyVersions/#{version_id}"
 
   # Get a version of the crypto key
   crypto_key_version = kms_client.get_project_location_key_ring_crypto_key_crypto_key_version resource
@@ -245,17 +245,17 @@ $enable_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto
     crypto_key_version, update_mask: "state"
   )
 
-  puts "Enabled version #{version} of #{crypto_key}"
+  puts "Enabled version #{version_id} of #{crypto_key_id}"
   # [END kms_enable_cryptokey_version]
 end
 
-$disable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location_id:) do
+$disable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key_id:, version_id:, location_id:) do
   # [START kms_disable_cryptokey_version]
-  # project_id  = "Your Google Cloud project ID"
-  # location_id = "The location of the key ring"
-  # key_ring_id = "The ID of the key ring"
-  # crypto_key  = "Name of the crypto key"
-  # version     = "Version of the crypto key"
+  # project_id    = "Your Google Cloud project ID"
+  # location_id   = "The location of the key ring"
+  # key_ring_id   = "The ID of the key ring"
+  # crypto_key_id = "The ID of the crypto key"
+  # version_id    = "Version of the crypto key"
 
   require "google/apis/cloudkms_v1"
 
@@ -266,12 +266,12 @@ $disable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, versio
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring crypto key version
+  # The resource name of the crypto key version
   resource = "projects/#{project_id}/locations/#{location_id}/" +
-             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
-             "cryptoKeyVersions/#{version}"
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}/" +
+             "cryptoKeyVersions/#{version_id}"
 
-  # Get a version of the crypto key
+  # Get a crypto key version
   crypto_key_version = kms_client.get_project_location_key_ring_crypto_key_crypto_key_version resource
 
   # Set the primary version state as disabled for update
@@ -283,17 +283,17 @@ $disable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, versio
     crypto_key_version, update_mask: "state"
   )
 
-  puts "Disabled version #{version} of #{crypto_key}"
+  puts "Disabled version #{version_id} of #{crypto_key_id}"
   # [END kms_disable_cryptokey_version]
 end
 
-$restore_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto_key:, version:) do
+$restore_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, version_id:) do
   # [START kms_restore_cryptokey_version]
-  # project_id  = "Your Google Cloud project ID"
-  # location_id = "The location of the key ring"
-  # key_ring_id = "The ID of the key ring"
-  # crypto_key  = "Name of the crypto key"
-  # version     = "Version of the crypto key"
+  # project_id    = "Your Google Cloud project ID"
+  # location_id   = "The location of the key ring"
+  # key_ring_id   = "The ID of the key ring"
+  # crypto_key_id = "The ID of the crypto key"
+  # version_id    = "Version of the crypto key"
 
   require "google/apis/cloudkms_v1"
 
@@ -304,10 +304,10 @@ $restore_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypt
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring crypto key version
+  # The resource name of the crypto key version
   resource = "projects/#{project_id}/locations/#{location_id}/" +
-             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
-             "cryptoKeyVersions/#{version}"
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}/" +
+             "cryptoKeyVersions/#{version_id}"
 
   # Restore specific version of the crypto key
   kms_client.restore_crypto_key_version(
@@ -315,18 +315,18 @@ $restore_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypt
     Cloudkms::RestoreCryptoKeyVersionRequest.new
   )
 
-  puts "Restored version #{version} of #{crypto_key}"
+  puts "Restored version #{version_id} of #{crypto_key_id}"
   # [END kms_restore_cryptokey_version]
 end
 
 
-$destroy_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto_key:, version:) do
+$destroy_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, version_id:) do
   # [START kms_destroy_cryptokey_version]
-  # project_id  = "Your Google Cloud project ID"
-  # location_id = "The location of the key ring"
-  # key_ring_id = "The ID of the key ring"
-  # crypto_key  = "Name of the crypto key"
-  # version     = "Version of the crypto key"
+  # project_id    = "Your Google Cloud project ID"
+  # location_id   = "The location of the key ring"
+  # key_ring_id   = "The ID of the key ring"
+  # crypto_key_id = "The ID of the crypto key"
+  # version_id    = "Version of the crypto key"
 
   require "google/apis/cloudkms_v1"
 
@@ -337,10 +337,10 @@ $destroy_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypt
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring crypto key version
+  # The resource name of the crypto key version
   resource = "projects/#{project_id}/locations/#{location_id}/" +
-             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
-             "cryptoKeyVersions/#{version}"
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}/" +
+             "cryptoKeyVersions/#{version_id}"
 
   # Destroy specific version of the crypto key
   kms_client.destroy_crypto_key_version(
@@ -348,7 +348,7 @@ $destroy_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypt
     Cloudkms::DestroyCryptoKeyVersionRequest.new
   )
 
-  puts "Destroyed version #{version} of #{crypto_key}"
+  puts "Destroyed version #{version_id} of #{crypto_key_id}"
   # [END kms_destroy_cryptokey_version]
 end
 
@@ -369,7 +369,7 @@ $add_member_to_key_ring_policy = -> (project_id:, location_id:, key_ring_id:, me
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring
+  # The resource name of the key ring
   resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}"
 
@@ -389,14 +389,14 @@ $add_member_to_key_ring_policy = -> (project_id:, location_id:, key_ring_id:, me
   # [END kms_add_member_to_keyring_policy]
 end
 
-$add_member_to_crypto_key_policy = -> (project_id:, location_id:, key_ring_id:, crypto_key:, member:, role:) do
+$add_member_to_crypto_key_policy = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, member:, role:) do
   # [START kms_add_member_to_cryptokey_policy]
-  # project_id  = "Your Google Cloud project ID"
-  # location_id = "The location of the key ring"
-  # key_ring_id = "The ID of the key ring"
-  # crypto_key  = "Name of the crypto key"
-  # member      = "Member to add to the crypto key policy"
-  # role        = "Role assignment for new member"
+  # project_id    = "Your Google Cloud project ID"
+  # location_id   = "The location of the key ring"
+  # key_ring_id   = "The ID of the key ring"
+  # crypto_key_id = "The ID of the crypto key"
+  # member        = "Member to add to the crypto key policy"
+  # role          = "Role assignment for new member"
 
   require "google/apis/cloudkms_v1"
 
@@ -407,9 +407,9 @@ $add_member_to_crypto_key_policy = -> (project_id:, location_id:, key_ring_id:, 
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring crypto key
+  # The resource name of the crypto key
   resource = "projects/#{project_id}/locations/#{location_id}/" +
-             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
   # Get the current IAM policy
   policy = kms_client.get_project_location_key_ring_crypto_key_iam_policy resource
@@ -423,18 +423,18 @@ $add_member_to_crypto_key_policy = -> (project_id:, location_id:, key_ring_id:, 
   kms_client.set_crypto_key_iam_policy resource, policy_request
 
   puts "Member #{member} added to policy for " +
-       "crypto key #{crypto_key} in key ring #{key_ring_id}"
+       "crypto key #{crypto_key_id} in key ring #{key_ring_id}"
   # [END kms_add_member_to_cryptokey_policy]
 end
 
-$remove_member_from_crypto_key_policy = -> (project_id:, location_id:, key_ring_id:, crypto_key:, member:, role:) do
+$remove_member_from_crypto_key_policy = -> (project_id:, location_id:, key_ring_id:, crypto_key_id:, member:, role:) do
   # [START kms_remove_member_from_cryptokey_policy]
-  # project_id  = "Your Google Cloud project ID"
-  # location_id = "The location of the key ring"
-  # key_ring_id = "The ID of the key ring"
-  # crypto_key  = "Name of the crypto key"
-  # member      = "Member to remove to the crypto key policy"
-  # role        = "Role assignment for the member"
+  # project_id    = "Your Google Cloud project ID"
+  # location_id   = "The location of the key ring"
+  # key_ring_id   = "The ID of the key ring"
+  # crypto_key_id = "The ID of the crypto key"
+  # member        = "Member to remove to the crypto key policy"
+  # role          = "Role assignment for the member"
 
   require "google/apis/cloudkms_v1"
 
@@ -445,9 +445,9 @@ $remove_member_from_crypto_key_policy = -> (project_id:, location_id:, key_ring_
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring crypto key
+  # The resource name of the crypto key
   resource = "projects/#{project_id}/locations/#{location_id}/" +
-             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
   # Get the current IAM policy
   policy = kms_client.get_project_location_key_ring_crypto_key_iam_policy resource
@@ -464,7 +464,7 @@ $remove_member_from_crypto_key_policy = -> (project_id:, location_id:, key_ring_
   kms_client.set_crypto_key_iam_policy resource, policy_request
 
   puts "Member #{member} removed from policy for " +
-       "crypto key #{crypto_key} in key ring #{key_ring_id}"
+       "crypto key #{crypto_key_id} in key ring #{key_ring_id}"
   # [END kms_remove_member_from_cryptokey_policy]
 end
 
@@ -483,7 +483,7 @@ $get_key_ring_policy = -> (project_id:, key_ring_id:, location_id:) do
     "https://www.googleapis.com/auth/cloud-platform"
   )
 
-  # The resource name of the location associated with the key ring
+  # The resource name of the key ring
   resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}"
 
@@ -517,14 +517,14 @@ def run_sample arguments
       project_id: project_id,
       location_id: arguments.shift,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift
+      crypto_key_id: arguments.shift
     )
   when "encrypt_file"
     $encrypt.call(
       project_id: project_id,
       location_id: arguments.shift,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
+      crypto_key_id: arguments.shift,
       input_file: arguments.shift,
       output_file: arguments.shift
     )
@@ -533,7 +533,7 @@ def run_sample arguments
       project_id: project_id,
       location_id: arguments.shift,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
+      crypto_key_id: arguments.shift,
       input_file: arguments.shift,
       output_file: arguments.shift
     )
@@ -542,38 +542,38 @@ def run_sample arguments
       project_id: project_id,
       location_id: arguments.shift,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift
+      crypto_key_id: arguments.shift
     )
   when "set_crypto_key_primary_version"
     $set_crypto_key_primary_version.call(
       project_id: project_id,
       location_id: arguments.shift,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
-      version: arguments.shift
+      crypto_key_id: arguments.shift,
+      version_id: arguments.shift
     )
   when "enable_crypto_key_version"
     $enable_crypto_key_version.call(
       project_id: project_id,
       location_id: arguments.shift,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
-      version: arguments.shift
+      crypto_key_id: arguments.shift,
+      version_id: arguments.shift
     )
   when "disable_crypto_key_version"
     $disable_crypto_key_version.call(
       project_id: project_id,
       location_id: arguments.shift,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
-      version: arguments.shift
+      crypto_key_id: arguments.shift,
+      version_id: arguments.shift
     )
   when "restore_crypto_key_version"
     $restore_crypto_key_version.call(
       project_id: project_id,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
-      version: arguments.shift,
+      crypto_key_id: arguments.shift,
+      version_id: arguments.shift,
       location_id: arguments.shift,
     )
   when "destroy_crypto_key_version"
@@ -581,8 +581,8 @@ def run_sample arguments
       project_id: project_id,
       location_id: arguments.shift,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
-      version: arguments.shift
+      crypto_key_id: arguments.shift,
+      version_id: arguments.shift
     )
   when "add_member_to_key_ring_policy"
     $add_member_to_key_ring_policy.call(
@@ -597,7 +597,7 @@ def run_sample arguments
       project_id: project_id,
       location_id: arguments.shift,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
+      crypto_key_id: arguments.shift,
       member: arguments.shift,
       role: arguments.shift
     )
@@ -606,7 +606,7 @@ def run_sample arguments
       project_id: project_id,
       location_id: arguments.shift,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
+      crypto_key_id: arguments.shift,
       member: arguments.shift,
       role: arguments.shift
     )

--- a/kms/kms.rb
+++ b/kms/kms.rb
@@ -16,11 +16,11 @@
 #       method definitions in Ruby. To allow for this, code snippets in this
 #       sample are wrapped in global lambdas.
 
-$create_key_ring = -> (project_id:, key_ring_id:, location:) do
+$create_key_ring = -> (project_id:, location_id:, key_ring_id:) do
   # [START kms_create_keyring]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the new key ring"
-  # location    = "The location of the new key ring"
+  # location_id = "The location of the new key ring"
 
   require "google/apis/cloudkms_v1"
 
@@ -32,7 +32,7 @@ $create_key_ring = -> (project_id:, key_ring_id:, location:) do
   )
 
   # The resource name of the location associated with the key ring
-  resource = "projects/#{project_id}/locations/#{location}"
+  resource = "projects/#{project_id}/locations/#{location_id}"
 
   # Create a key ring for your project
   key_ring = kms_client.create_project_location_key_ring(
@@ -45,12 +45,12 @@ $create_key_ring = -> (project_id:, key_ring_id:, location:) do
   # [END kms_create_keyring]
 end
 
-$create_crypto_key = -> (project_id:, key_ring_id:, crypto_key:, location:) do
+$create_crypto_key = -> (project_id:, location_id:, key_ring_id:, crypto_key:) do
   # [START kms_create_cryptokey]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the new key ring"
   # crypto_key  = "Name of the crypto key"
-  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1"
 
@@ -62,7 +62,7 @@ $create_crypto_key = -> (project_id:, key_ring_id:, crypto_key:, location:) do
   )
 
   # The resource name of the location associated with the key ring
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}"
 
   # Create a crypto key for your project key ring
@@ -76,12 +76,12 @@ $create_crypto_key = -> (project_id:, key_ring_id:, crypto_key:, location:) do
   # [END kms_create_cryptokey]
 end
 
-$encrypt = -> (project_id:, key_ring_id:, crypto_key:, location:, input_file:, output_file:) do
+$encrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key:, input_file:, output_file:) do
   # [START kms_encrypt]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
-  # location    = "The location of the key ring"
   # input_file  = "File to encrypt"
   # output_file = "File name to use for encrypted input file"
 
@@ -95,7 +95,7 @@ $encrypt = -> (project_id:, key_ring_id:, crypto_key:, location:, input_file:, o
   )
 
   # The resource name of the location associated with the key ring crypto key
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
   # Use the KMS API to encrypt the text
@@ -112,12 +112,12 @@ $encrypt = -> (project_id:, key_ring_id:, crypto_key:, location:, input_file:, o
   # [END kms_encrypt]
 end
 
-$decrypt = -> (project_id:, key_ring_id:, crypto_key:, location:, input_file:, output_file:) do
+$decrypt = -> (project_id:, location_id:, key_ring_id:, crypto_key:, input_file:, output_file:) do
   # [START kms_decrypt]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
-  # location    = "The location of the key ring"
   # input_file  = "The path to an encrypted file"
   # output_file = "The path to write the decrypted file"
 
@@ -131,7 +131,7 @@ $decrypt = -> (project_id:, key_ring_id:, crypto_key:, location:, input_file:, o
   )
 
   # The resource name of the location associated with the key ring crypto key
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
   # Use the KMS API to decrypt the text
@@ -148,12 +148,12 @@ $decrypt = -> (project_id:, key_ring_id:, crypto_key:, location:, input_file:, o
   # [END kms_decrypt]
 end
 
-$create_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, location:) do
+$create_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto_key:) do
   # [START kms_create_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the new crypto key"
-  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1"
 
@@ -165,7 +165,7 @@ $create_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, locatio
   )
 
   # The resource name of the location associated with the key ring crypto key
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
   # Create the crypto key version for your project
@@ -179,13 +179,13 @@ $create_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, locatio
   # [END kms_create_cryptokey_version]
 end
 
-$set_crypto_key_primary_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
+$set_crypto_key_primary_version = -> (project_id:, location_id:, key_ring_id:, crypto_key:, version:) do
   # [START kms_set_cryptokey_primary_version]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # version     = "Version of the crypto key"
-  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1"
 
@@ -197,7 +197,7 @@ $set_crypto_key_primary_version = -> (project_id:, key_ring_id:, crypto_key:, ve
   )
 
   # The resource name of the location associated with the key ring crypto key
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
   # Update the CryptoKey primary version
@@ -211,13 +211,13 @@ $set_crypto_key_primary_version = -> (project_id:, key_ring_id:, crypto_key:, ve
   # [END kms_set_cryptokey_primary_version]
 end
 
-$enable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
+$enable_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto_key:, version:) do
   # [START kms_enable_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # version     = "Version of the crypto key"
-  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1"
 
@@ -229,7 +229,7 @@ $enable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, version
   )
 
   # The resource name of the location associated with the key ring crypto key version
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
              "cryptoKeyVersions/#{version}"
 
@@ -249,13 +249,13 @@ $enable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, version
   # [END kms_enable_cryptokey_version]
 end
 
-$disable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
+$disable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location_id:) do
   # [START kms_disable_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # version     = "Version of the crypto key"
-  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1"
 
@@ -267,7 +267,7 @@ $disable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, versio
   )
 
   # The resource name of the location associated with the key ring crypto key version
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
              "cryptoKeyVersions/#{version}"
 
@@ -287,13 +287,13 @@ $disable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, versio
   # [END kms_disable_cryptokey_version]
 end
 
-$restore_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
+$restore_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto_key:, version:) do
   # [START kms_restore_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # version     = "Version of the crypto key"
-  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1"
 
@@ -305,7 +305,7 @@ $restore_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, versio
   )
 
   # The resource name of the location associated with the key ring crypto key version
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
              "cryptoKeyVersions/#{version}"
 
@@ -320,13 +320,13 @@ $restore_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, versio
 end
 
 
-$destroy_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
+$destroy_crypto_key_version = -> (project_id:, location_id:, key_ring_id:, crypto_key:, version:) do
   # [START kms_destroy_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # version     = "Version of the crypto key"
-  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1"
 
@@ -338,7 +338,7 @@ $destroy_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, versio
   )
 
   # The resource name of the location associated with the key ring crypto key version
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
              "cryptoKeyVersions/#{version}"
 
@@ -352,13 +352,13 @@ $destroy_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, versio
   # [END kms_destroy_cryptokey_version]
 end
 
-$add_member_to_key_ring_policy = -> (project_id:, key_ring_id:, member:, role:, location:) do
+$add_member_to_key_ring_policy = -> (project_id:, location_id:, key_ring_id:, member:, role:) do
   # [START kms_add_member_to_keyring_policy]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the key ring"
   # member      = "Member to add to the key ring policy"
   # role        = "Role assignment for new member"
-  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1"
 
@@ -370,7 +370,7 @@ $add_member_to_key_ring_policy = -> (project_id:, key_ring_id:, member:, role:, 
   )
 
   # The resource name of the location associated with the key ring
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}"
 
   # Get the current IAM policy
@@ -389,14 +389,14 @@ $add_member_to_key_ring_policy = -> (project_id:, key_ring_id:, member:, role:, 
   # [END kms_add_member_to_keyring_policy]
 end
 
-$add_member_to_crypto_key_policy = -> (project_id:, key_ring_id:, crypto_key:, member:, role:, location:) do
+$add_member_to_crypto_key_policy = -> (project_id:, location_id:, key_ring_id:, crypto_key:, member:, role:) do
   # [START kms_add_member_to_cryptokey_policy]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # member      = "Member to add to the crypto key policy"
   # role        = "Role assignment for new member"
-  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1"
 
@@ -408,7 +408,7 @@ $add_member_to_crypto_key_policy = -> (project_id:, key_ring_id:, crypto_key:, m
   )
 
   # The resource name of the location associated with the key ring crypto key
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
   # Get the current IAM policy
@@ -427,14 +427,14 @@ $add_member_to_crypto_key_policy = -> (project_id:, key_ring_id:, crypto_key:, m
   # [END kms_add_member_to_cryptokey_policy]
 end
 
-$remove_member_from_crypto_key_policy = -> (project_id:, key_ring_id:, crypto_key:, member:, role:, location:) do
+$remove_member_from_crypto_key_policy = -> (project_id:, location_id:, key_ring_id:, crypto_key:, member:, role:) do
   # [START kms_remove_member_from_cryptokey_policy]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the key ring"
   # crypto_key  = "Name of the crypto key"
   # member      = "Member to remove to the crypto key policy"
   # role        = "Role assignment for the member"
-  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1"
 
@@ -446,7 +446,7 @@ $remove_member_from_crypto_key_policy = -> (project_id:, key_ring_id:, crypto_ke
   )
 
   # The resource name of the location associated with the key ring crypto key
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
   # Get the current IAM policy
@@ -468,11 +468,11 @@ $remove_member_from_crypto_key_policy = -> (project_id:, key_ring_id:, crypto_ke
   # [END kms_remove_member_from_cryptokey_policy]
 end
 
-$get_key_ring_policy = -> (project_id:, key_ring_id:, location:) do
+$get_key_ring_policy = -> (project_id:, key_ring_id:, location_id:) do
   # [START kms_get_keyring_policy]
   # project_id  = "Your Google Cloud project ID"
+  # location_id = "The location of the key ring"
   # key_ring_id = "The ID of the key ring"
-  # location    = "The location of the key ring"
 
   require "google/apis/cloudkms_v1"
 
@@ -484,7 +484,7 @@ $get_key_ring_policy = -> (project_id:, key_ring_id:, location:) do
   )
 
   # The resource name of the location associated with the key ring
-  resource = "projects/#{project_id}/locations/#{location}/" +
+  resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}"
 
   # Get the current IAM policy
@@ -509,64 +509,64 @@ def run_sample arguments
   when "create_key_ring"
     $create_key_ring.call(
       project_id: project_id,
-      key_ring_id: arguments.shift,
-      location: arguments.shift
+      location_id: arguments.shift,
+      key_ring_id: arguments.shift
     )
   when "create_crypto_key"
     $create_crypto_key.call(
       project_id: project_id,
+      location_id: arguments.shift,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
-      location: arguments.shift
+      crypto_key: arguments.shift
     )
   when "encrypt_file"
     $encrypt.call(
       project_id: project_id,
+      location_id: arguments.shift,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
-      location: arguments.shift,
       input_file: arguments.shift,
       output_file: arguments.shift
     )
   when "decrypt_file"
     $decrypt.call(
       project_id: project_id,
+      location_id: arguments.shift,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
-      location: arguments.shift,
       input_file: arguments.shift,
       output_file: arguments.shift
     )
   when "create_crypto_key_version"
     $create_crypto_key_version.call(
       project_id: project_id,
+      location_id: arguments.shift,
       key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
-      location: arguments.shift
+      crypto_key: arguments.shift
     )
   when "set_crypto_key_primary_version"
     $set_crypto_key_primary_version.call(
       project_id: project_id,
+      location_id: arguments.shift,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
-      version: arguments.shift,
-      location: arguments.shift
+      version: arguments.shift
     )
   when "enable_crypto_key_version"
     $enable_crypto_key_version.call(
       project_id: project_id,
+      location_id: arguments.shift,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
-      version: arguments.shift,
-      location: arguments.shift
+      version: arguments.shift
     )
   when "disable_crypto_key_version"
     $disable_crypto_key_version.call(
       project_id: project_id,
+      location_id: arguments.shift,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
-      version: arguments.shift,
-      location: arguments.shift
+      version: arguments.shift
     )
   when "restore_crypto_key_version"
     $restore_crypto_key_version.call(
@@ -574,67 +574,67 @@ def run_sample arguments
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
       version: arguments.shift,
-      location: arguments.shift
+      location_id: arguments.shift,
     )
   when "destroy_crypto_key_version"
     $destroy_crypto_key_version.call(
       project_id: project_id,
+      location_id: arguments.shift,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
-      version: arguments.shift,
-      location: arguments.shift
+      version: arguments.shift
     )
   when "add_member_to_key_ring_policy"
     $add_member_to_key_ring_policy.call(
       project_id: project_id,
+      location_id: arguments.shift,
       key_ring_id: arguments.shift,
       member: arguments.shift,
-      role: arguments.shift,
-      location: arguments.shift
+      role: arguments.shift
     )
   when "add_member_to_crypto_key_policy"
     $add_member_to_crypto_key_policy.call(
       project_id: project_id,
+      location_id: arguments.shift,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
       member: arguments.shift,
-      role: arguments.shift,
-      location: arguments.shift
+      role: arguments.shift
     )
   when "remove_member_from_crypto_key_policy"
     $remove_member_from_crypto_key_policy.call(
       project_id: project_id,
+      location_id: arguments.shift,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
       member: arguments.shift,
-      role: arguments.shift,
-      location: arguments.shift
+      role: arguments.shift
     )
   when "get_key_ring_policy"
     $get_key_ring_policy.call(
       project_id: project_id,
-      key_ring_id: arguments.shift,
-      location: arguments.shift
+      location_id: arguments.shift,
+      key_ring_id: arguments.shift
     )
   else
     puts <<-usage
 Usage: bundle exec ruby kms.rb [command] [arguments]
 
 Commands:
-  create_key_ring                      <key_ring> <location> Create a new key ring
-  create_crypto_key                    <key_ring> <crypto_key> <location> Create a new crypto key
-  encrypt_file                         <key_ring> <crypto_key> <location> <input_file> <output_file> Encrypt a file
-  decrypt_file                         <key_ring> <crypto_key> <location> <input_file> <output_file> Decrypt a file
-  create_crypto_key_version            <key_ring> <crypto_key> <location> Create a new crypto key version
-  set_crypto_key_primary_version       <key_ring> <crypto_key> <verison> <location> Set a primary crypto key version
-  enable_crypto_key_version            <key_ring> <crypto_key> <version> <location> Enable a crypto key version
-  disable_crypto_key_version           <key_ring> <crypto_key> <version> <location> Disable a crypto key version
-  restore_crypto_key_version           <key_ring> <crypto_key> <version> <location> Restore a crypto key version
-  destroy_crypto_key_version           <key_ring> <crypto_key> <version> <location> Destroy a crypto key version
-  add_member_to_key_ring_policy        <key_ring> <member> <role> <location> Add member to key ring IAM policy
-  add_member_to_crypto_key_policy      <key_ring> <crypto_key> <member> <role> <location> Add member to crypto key IAM policy
-  remove_member_from_crypto_key_policy <key_ring> <crypto_key> <member> <role> <location> Remove member from crypto key IAM policy
-  get_key_ring_policy                  <key_ring> <location> Get a key ring IAM policy
+  create_key_ring                      <location> <key_ring> Create a new key ring
+  create_crypto_key                    <location> <key_ring> <crypto_key> Create a new crypto key
+  encrypt_file                         <location> <key_ring> <crypto_key> <input_file> <output_file> Encrypt a file
+  decrypt_file                         <location> <key_ring> <crypto_key> <input_file> <output_file> Decrypt a file
+  create_crypto_key_version            <location> <key_ring> <crypto_key> Create a new crypto key version
+  set_crypto_key_primary_version       <location> <key_ring> <crypto_key> <verison> Set a primary crypto key version
+  enable_crypto_key_version            <location> <key_ring> <crypto_key> <version> Enable a crypto key version
+  disable_crypto_key_version           <location> <key_ring> <crypto_key> <version> Disable a crypto key version
+  restore_crypto_key_version           <location> <key_ring> <crypto_key> <version> Restore a crypto key version
+  destroy_crypto_key_version           <location> <key_ring> <crypto_key> <version> Destroy a crypto key version
+  add_member_to_key_ring_policy        <location> <key_ring> <member> <role> Add member to key ring IAM policy
+  add_member_to_crypto_key_policy      <location> <key_ring> <crypto_key> <member> <role> Add member to crypto key IAM policy
+  remove_member_from_crypto_key_policy <location> <key_ring> <crypto_key> <member> <role> Remove member from crypto key IAM policy
+  get_key_ring_policy                  <location> <key_ring> Get a key ring IAM policy
 
 Environment variables:
   GOOGLE_CLOUD_PROJECT must be set to your Google Cloud project ID

--- a/kms/kms.rb
+++ b/kms/kms.rb
@@ -16,7 +16,7 @@
 #       method definitions in Ruby. To allow for this, code snippets in this
 #       sample are wrapped in global lambdas.
 
-$create_keyring = -> (project_id:, key_ring_id:, location:) do
+$create_key_ring = -> (project_id:, key_ring_id:, location:) do
   # [START kms_create_keyring]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the new key ring"
@@ -45,7 +45,7 @@ $create_keyring = -> (project_id:, key_ring_id:, location:) do
   # [END kms_create_keyring]
 end
 
-$create_cryptokey = -> (project_id:, key_ring_id:, crypto_key:, location:) do
+$create_crypto_key = -> (project_id:, key_ring_id:, crypto_key:, location:) do
   # [START kms_create_cryptokey]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the new key ring"
@@ -148,7 +148,7 @@ $decrypt = -> (project_id:, key_ring_id:, crypto_key:, location:, input_file:, o
   # [END kms_decrypt]
 end
 
-$create_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, location:) do
+$create_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, location:) do
   # [START kms_create_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the key ring"
@@ -179,7 +179,7 @@ $create_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, location
   # [END kms_create_cryptokey_version]
 end
 
-$set_cryptokey_primary_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
+$set_crypto_key_primary_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
   # [START kms_set_cryptokey_primary_version]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the key ring"
@@ -211,7 +211,7 @@ $set_cryptokey_primary_version = -> (project_id:, key_ring_id:, crypto_key:, ver
   # [END kms_set_cryptokey_primary_version]
 end
 
-$enable_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
+$enable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
   # [START kms_enable_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the key ring"
@@ -249,7 +249,7 @@ $enable_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:
   # [END kms_enable_cryptokey_version]
 end
 
-$disable_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
+$disable_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
   # [START kms_disable_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the key ring"
@@ -287,7 +287,7 @@ $disable_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version
   # [END kms_disable_cryptokey_version]
 end
 
-$restore_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
+$restore_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
   # [START kms_restore_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the key ring"
@@ -320,7 +320,7 @@ $restore_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version
 end
 
 
-$destroy_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
+$destroy_crypto_key_version = -> (project_id:, key_ring_id:, crypto_key:, version:, location:) do
   # [START kms_destroy_cryptokey_version]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the key ring"
@@ -352,7 +352,7 @@ $destroy_cryptokey_version = -> (project_id:, key_ring_id:, crypto_key:, version
   # [END kms_destroy_cryptokey_version]
 end
 
-$add_member_to_keyring_policy = -> (project_id:, key_ring_id:, member:, role:, location:) do
+$add_member_to_key_ring_policy = -> (project_id:, key_ring_id:, member:, role:, location:) do
   # [START kms_add_member_to_keyring_policy]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the key ring"
@@ -389,7 +389,7 @@ $add_member_to_keyring_policy = -> (project_id:, key_ring_id:, member:, role:, l
   # [END kms_add_member_to_keyring_policy]
 end
 
-$add_member_to_cryptokey_policy = -> (project_id:, key_ring_id:, crypto_key:, member:, role:, location:) do
+$add_member_to_crypto_key_policy = -> (project_id:, key_ring_id:, crypto_key:, member:, role:, location:) do
   # [START kms_add_member_to_cryptokey_policy]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the key ring"
@@ -427,7 +427,7 @@ $add_member_to_cryptokey_policy = -> (project_id:, key_ring_id:, crypto_key:, me
   # [END kms_add_member_to_cryptokey_policy]
 end
 
-$remove_member_from_cryptokey_policy = -> (project_id:, key_ring_id:, crypto_key:, member:, role:, location:) do
+$remove_member_from_crypto_key_policy = -> (project_id:, key_ring_id:, crypto_key:, member:, role:, location:) do
   # [START kms_remove_member_from_cryptokey_policy]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the key ring"
@@ -468,7 +468,7 @@ $remove_member_from_cryptokey_policy = -> (project_id:, key_ring_id:, crypto_key
   # [END kms_remove_member_from_cryptokey_policy]
 end
 
-$get_keyring_policy = -> (project_id:, key_ring_id:, location:) do
+$get_key_ring_policy = -> (project_id:, key_ring_id:, location:) do
   # [START kms_get_keyring_policy]
   # project_id  = "Your Google Cloud project ID"
   # key_ring_id = "The ID of the key ring"
@@ -506,14 +506,14 @@ def run_sample arguments
   project_id = ENV["GOOGLE_CLOUD_PROJECT"]
 
   case command
-  when "create_keyring"
-    $create_keyring.call(
+  when "create_key_ring"
+    $create_key_ring.call(
       project_id: project_id,
       key_ring_id: arguments.shift,
       location: arguments.shift
     )
-  when "create_cryptokey"
-    $create_cryptokey.call(
+  when "create_crypto_key"
+    $create_crypto_key.call(
       project_id: project_id,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
@@ -537,72 +537,63 @@ def run_sample arguments
       input_file: arguments.shift,
       output_file: arguments.shift
     )
-  when "create_cryptokey_version"
-    $create_cryptokey_version.call(
+  when "create_crypto_key_version"
+    $create_crypto_key_version.call(
       project_id: project_id,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
       location: arguments.shift
     )
-  when "set_cryptokey_primary_version"
-    $set_cryptokey_primary_version.call(
-      project_id: project_id,
-      key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
-      version: arguments.shift,
-      location: arguments.shift
-    )
-  when "enable_cryptokey_version"
-    $enable_cryptokey_version.call(
+  when "set_crypto_key_primary_version"
+    $set_crypto_key_primary_version.call(
       project_id: project_id,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
       version: arguments.shift,
       location: arguments.shift
     )
-  when "disable_cryptokey_version"
-    $disable_cryptokey_version.call(
+  when "enable_crypto_key_version"
+    $enable_crypto_key_version.call(
       project_id: project_id,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
       version: arguments.shift,
       location: arguments.shift
     )
-  when "restore_cryptokey_version"
-    $restore_cryptokey_version.call(
+  when "disable_crypto_key_version"
+    $disable_crypto_key_version.call(
       project_id: project_id,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
       version: arguments.shift,
       location: arguments.shift
     )
-  when "destroy_cryptokey_version"
-    $destroy_cryptokey_version.call(
+  when "restore_crypto_key_version"
+    $restore_crypto_key_version.call(
       project_id: project_id,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
       version: arguments.shift,
       location: arguments.shift
     )
-  when "add_member_to_keyring_policy"
-    $add_member_to_keyring_policy.call(
+  when "destroy_crypto_key_version"
+    $destroy_crypto_key_version.call(
+      project_id: project_id,
+      key_ring_id: arguments.shift,
+      crypto_key: arguments.shift,
+      version: arguments.shift,
+      location: arguments.shift
+    )
+  when "add_member_to_key_ring_policy"
+    $add_member_to_key_ring_policy.call(
       project_id: project_id,
       key_ring_id: arguments.shift,
       member: arguments.shift,
       role: arguments.shift,
       location: arguments.shift
     )
-  when "add_member_to_cryptokey_policy"
-    $add_member_to_cryptokey_policy.call(
-      project_id: project_id,
-      key_ring_id: arguments.shift,
-      crypto_key: arguments.shift,
-      member: arguments.shift,
-      role: arguments.shift,
-      location: arguments.shift
-    )
-  when "remove_member_from_cryptokey_policy"
-    $remove_member_from_cryptokey_policy.call(
+  when "add_member_to_crypto_key_policy"
+    $add_member_to_crypto_key_policy.call(
       project_id: project_id,
       key_ring_id: arguments.shift,
       crypto_key: arguments.shift,
@@ -610,8 +601,17 @@ def run_sample arguments
       role: arguments.shift,
       location: arguments.shift
     )
-  when "get_keyring_policy"
-    $get_keyring_policy.call(
+  when "remove_member_from_crypto_key_policy"
+    $remove_member_from_crypto_key_policy.call(
+      project_id: project_id,
+      key_ring_id: arguments.shift,
+      crypto_key: arguments.shift,
+      member: arguments.shift,
+      role: arguments.shift,
+      location: arguments.shift
+    )
+  when "get_key_ring_policy"
+    $get_key_ring_policy.call(
       project_id: project_id,
       key_ring_id: arguments.shift,
       location: arguments.shift
@@ -621,20 +621,20 @@ def run_sample arguments
 Usage: bundle exec ruby kms.rb [command] [arguments]
 
 Commands:
-  create_keyring                      <key_ring> <location> Create a new keyring
-  create_cryptokey                    <key_ring> <crypto_key> <location> Create a new cryptokey
-  encrypt_file                        <key_ring> <crypto_key> <location> <input_file> <output_file> Encrypt a file
-  decrypt_file                        <key_ring> <crypto_key> <location> <input_file> <output_file> Decrypt a file
-  create_cryptokey_version            <key_ring> <crypto_key> <location> Create a new cryptokey version
-  set_cryptokey_primary_version       <key_ring> <crypto_key> <verison> <location> Set a primary cryptokey version
-  enable_cryptokey_version            <key_ring> <crypto_key> <version> <location> Enable a cryptokey version
-  disable_cryptokey_version           <key_ring> <crypto_key> <version> <location> Disable a cryptokey version
-  restore_cryptokey_version           <key_ring> <crypto_key> <version> <location> Restore a cryptokey version
-  destroy_cryptokey_version           <key_ring> <crypto_key> <version> <location> Destroy a cryptokey version
-  add_member_to_keyring_policy        <key_ring> <member> <role> <location> Add member to keyring IAM policy
-  add_member_to_cryptokey_policy      <key_ring> <crypto_key> <member> <role> <location> Add member to cryptokey IAM policy
-  remove_member_from_cryptokey_policy <key_ring> <crypto_key> <member> <role> <location> Remove member from cryptokey IAM policy
-  get_keyring_policy                  <key_ring> <location> Get a keyring IAM policy
+  create_key_ring                      <key_ring> <location> Create a new key ring
+  create_crypto_key                    <key_ring> <crypto_key> <location> Create a new crypto key
+  encrypt_file                         <key_ring> <crypto_key> <location> <input_file> <output_file> Encrypt a file
+  decrypt_file                         <key_ring> <crypto_key> <location> <input_file> <output_file> Decrypt a file
+  create_crypto_key_version            <key_ring> <crypto_key> <location> Create a new crypto key version
+  set_crypto_key_primary_version       <key_ring> <crypto_key> <verison> <location> Set a primary crypto key version
+  enable_crypto_key_version            <key_ring> <crypto_key> <version> <location> Enable a crypto key version
+  disable_crypto_key_version           <key_ring> <crypto_key> <version> <location> Disable a crypto key version
+  restore_crypto_key_version           <key_ring> <crypto_key> <version> <location> Restore a crypto key version
+  destroy_crypto_key_version           <key_ring> <crypto_key> <version> <location> Destroy a crypto key version
+  add_member_to_key_ring_policy        <key_ring> <member> <role> <location> Add member to key ring IAM policy
+  add_member_to_crypto_key_policy      <key_ring> <crypto_key> <member> <role> <location> Add member to crypto key IAM policy
+  remove_member_from_crypto_key_policy <key_ring> <crypto_key> <member> <role> <location> Remove member from crypto key IAM policy
+  get_key_ring_policy                  <key_ring> <location> Get a key ring IAM policy
 
 Environment variables:
   GOOGLE_CLOUD_PROJECT must be set to your Google Cloud project ID

--- a/kms/quickstart.rb
+++ b/kms/quickstart.rb
@@ -20,7 +20,7 @@ require "google/apis/cloudkms_v1"
 project_id = "YOUR_PROJECT_ID"
 
 # Lists keys in the "global" location.
-location = "global"
+location_id = "global"
 
 # Instantiate the client
 Cloudkms   = Google::Apis::CloudkmsV1 # Alias the module
@@ -33,7 +33,7 @@ kms_client.authorization = Google::Auth.get_application_default(
 )
 
 # The resource name of the location associated with the key rings
-parent = "projects/#{project_id}/locations/#{location}"
+parent = "projects/#{project_id}/locations/#{location_id}"
 
 # Request list of key rings
 response = kms_client.list_project_location_key_rings parent

--- a/kms/quickstart.rb
+++ b/kms/quickstart.rb
@@ -32,7 +32,7 @@ kms_client.authorization = Google::Auth.get_application_default(
   "https://www.googleapis.com/auth/cloud-platform"
 )
 
-# The resource name of the location associated with the Key rings
+# The resource name of the location associated with the key rings
 parent = "projects/#{project_id}/locations/#{location}"
 
 # Request list of key rings

--- a/kms/spec/kms_spec.rb
+++ b/kms/spec/kms_spec.rb
@@ -27,10 +27,10 @@ describe "Key Management Service" do
     kms_client
   end
 
-  def create_test_key_ring project_id:, key_ring_id:, location:
+  def create_test_key_ring project_id:, location_id:, key_ring_id:
     kms_client = create_service_client
 
-    resource = "projects/#{project_id}/locations/#{location}"
+    resource = "projects/#{project_id}/locations/#{location_id}"
 
     kms_client.create_project_location_key_ring(
       resource,
@@ -39,19 +39,19 @@ describe "Key Management Service" do
     )
   end
 
-  def get_test_key_ring project_id:, key_ring_id:, location:
+  def get_test_key_ring project_id:, location_id:, key_ring_id:
     kms_client = create_service_client
 
-    resource = "projects/#{project_id}/locations/#{location}/" +
+    resource = "projects/#{project_id}/locations/#{location_id}/" +
                "keyRings/#{key_ring_id}"
 
     kms_client.get_project_location_key_ring resource
   end
 
-  def create_test_crypto_key project_id:, key_ring_id:, crypto_key:, location:
+  def create_test_crypto_key project_id:, location_id:, key_ring_id:, crypto_key:
     kms_client = create_service_client
 
-    resource = "projects/#{project_id}/locations/#{location}/" +
+    resource = "projects/#{project_id}/locations/#{location_id}/" +
                "keyRings/#{key_ring_id}"
 
     kms_client.create_project_location_key_ring_crypto_key(
@@ -63,10 +63,10 @@ describe "Key Management Service" do
     )
   end
 
-  def create_test_crypto_key_version project_id:, key_ring_id:, crypto_key:, location:
+  def create_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key:
     kms_client = create_service_client
 
-    resource = "projects/#{project_id}/locations/#{location}/" +
+    resource = "projects/#{project_id}/locations/#{location_id}/" +
                "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
     crypto_key_version = kms_client.create_project_location_key_ring_crypto_key_crypto_key_version(
@@ -75,11 +75,11 @@ describe "Key Management Service" do
     )
   end
 
-  def destroy_test_crypto_key_version project_id:, key_ring_id:, crypto_key:, version:, location:
+  def destroy_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key:, version:
     kms_client = create_service_client
 
     # The resource name of the location associated with the key ring
-    resource = "projects/#{project_id}/locations/#{location}/" +
+    resource = "projects/#{project_id}/locations/#{location_id}/" +
                "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
                "cryptoKeyVersions/#{version}"
 
@@ -90,10 +90,10 @@ describe "Key Management Service" do
     )
   end
 
-  def disable_test_crypto_key_version project_id:, key_ring_id:, crypto_key:, version:, location:
+  def disable_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key:, version:
     kms_client = create_service_client
 
-    resource = "projects/#{project_id}/locations/#{location}/" +
+    resource = "projects/#{project_id}/locations/#{location_id}/" +
              "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
              "cryptoKeyVersions/#{version}"
 
@@ -110,30 +110,30 @@ describe "Key Management Service" do
     )
   end
 
-  def get_test_crypto_key project_id:, key_ring_id:, crypto_key:, location:
+  def get_test_crypto_key project_id:, location_id:, key_ring_id:, crypto_key:
     kms_client = create_service_client
 
-    resource = "projects/#{project_id}/locations/#{location}/" +
+    resource = "projects/#{project_id}/locations/#{location_id}/" +
                "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
     kms_client.get_project_location_key_ring_crypto_key resource
   end
 
-  def get_test_crypto_key_version project_id:, key_ring_id:, crypto_key:, version:, location:
+  def get_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key:, version:
 
     kms_client = create_service_client
 
-    name = "projects/#{project_id}/locations/#{location}/" +
+    name = "projects/#{project_id}/locations/#{location_id}/" +
            "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
            "cryptoKeyVersions/#{version}"
 
     kms_client.get_project_location_key_ring_crypto_key_crypto_key_version name
   end
 
-  def list_test_crypto_key_version project_id:, key_ring_id:, crypto_key:, location:
+  def list_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key:
     kms_client = create_service_client
 
-    resource = "projects/#{project_id}/locations/#{location}/" +
+    resource = "projects/#{project_id}/locations/#{location_id}/" +
                "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
     kms_client.list_project_location_key_ring_crypto_key_crypto_key_versions(
@@ -141,36 +141,36 @@ describe "Key Management Service" do
     )
   end
 
-  def list_test_key_rings project_id:, location:
+  def list_test_key_rings project_id:, location_id:
     kms_client = create_service_client
 
-    resource = "projects/#{project_id}/locations/#{location}"
+    resource = "projects/#{project_id}/locations/#{location_id}"
 
     kms_client.list_project_location_key_rings resource
   end
 
-  def get_test_crypto_key_policy project_id:, key_ring_id:, crypto_key:, location:
+  def get_test_crypto_key_policy project_id:, location_id:, key_ring_id:, crypto_key:
     kms_client = create_service_client
 
-    resource = "projects/#{project_id}/locations/#{location}/" +
+    resource = "projects/#{project_id}/locations/#{location_id}/" +
                "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
     kms_client.get_project_location_key_ring_crypto_key_iam_policy resource
   end
 
-  def get_test_key_ring_policy project_id:, key_ring_id:, location:
+  def get_test_key_ring_policy project_id:, location_id:, key_ring_id:
     kms_client = create_service_client
 
-    resource = "projects/#{project_id}/locations/#{location}/" +
+    resource = "projects/#{project_id}/locations/#{location_id}/" +
                "keyRings/#{key_ring_id}"
 
     kms_client.get_project_location_key_ring_iam_policy resource
   end
 
-  def add_test_member_to_crypto_key_policy project_id:, key_ring_id:, crypto_key:, member:, role:, location:
+  def add_test_member_to_crypto_key_policy project_id:, location_id:, key_ring_id:, crypto_key:, member:, role:
     kms_client = create_service_client
 
-    resource = "projects/#{project_id}/locations/#{location}/" +
+    resource = "projects/#{project_id}/locations/#{location_id}/" +
                "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
     policy = kms_client.get_project_location_key_ring_crypto_key_iam_policy resource
@@ -188,16 +188,16 @@ describe "Key Management Service" do
     kms_client.set_crypto_key_iam_policy resource, policy_request
   end
 
-  def add_test_member_to_key_ring_policy project_id:, key_ring_id:, member:, role:, location:
+  def add_test_member_to_key_ring_policy project_id:, location_id:, key_ring_id:, member:, role:
     kms_client = create_service_client
 
     policy = get_test_key_ring_policy(
       project_id: project_id,
-      key_ring_id: key_ring_id,
-      location: location
+      location_id: location_id,
+      key_ring_id: key_ring_id
     )
 
-    resource = "projects/#{project_id}/locations/#{location}/" +
+    resource = "projects/#{project_id}/locations/#{location_id}/" +
                "keyRings/#{key_ring_id}"
 
 
@@ -214,16 +214,16 @@ describe "Key Management Service" do
     kms_client.set_key_ring_iam_policy resource, policy_request
   end
 
-  def remove_test_member_to_key_ring_policy project_id:, key_ring_id:, member:, role:, location:
+  def remove_test_member_to_key_ring_policy project_id:, location_id:, key_ring_id:, member:, role:
     kms_client = create_service_client
 
     policy = get_test_key_ring_policy(
       project_id: project_id,
-      key_ring_id: key_ring_id,
-      location: location
+      location_id: location_id,
+      key_ring_id: key_ring_id
     )
 
-    resource = "projects/#{project_id}/locations/#{location}/" +
+    resource = "projects/#{project_id}/locations/#{location_id}/" +
                "keyRings/#{key_ring_id}"
 
     if policy.bindings
@@ -239,10 +239,10 @@ describe "Key Management Service" do
     kms_client.set_key_ring_iam_policy resource, policy_request
   end
 
-  def encrypt_test_file project_id:, key_ring_id:, crypto_key:, location:, input_file:, output_file:
+  def encrypt_test_file project_id:, location_id:, key_ring_id:, crypto_key:, input_file:, output_file:
     kms_client = create_service_client
 
-    name = "projects/#{project_id}/locations/#{location}/" +
+    name = "projects/#{project_id}/locations/#{location_id}/" +
            "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
     plain_text = File.read input_file
@@ -256,10 +256,10 @@ describe "Key Management Service" do
     File.write output_file, response.ciphertext
   end
 
-  def decrypt_test_file project_id:, key_ring_id:, crypto_key:, location:, input_file:, output_file:
+  def decrypt_test_file project_id:, location_id:, key_ring_id:, crypto_key:, input_file:, output_file:
     kms_client = create_service_client
 
-    name = "projects/#{project_id}/locations/#{location}/" +
+    name = "projects/#{project_id}/locations/#{location_id}/" +
            "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
 
     encrypted_text = File.read input_file
@@ -274,16 +274,17 @@ describe "Key Management Service" do
   end
 
   before :all do
-    @project_id   = ENV["GOOGLE_CLOUD_PROJECT"]
-    @key_ring_id  = "#{@project_id}_key_ring_#{Time.now.to_i}"
+    @project_id    = ENV["GOOGLE_CLOUD_PROJECT"]
+    @location_id   = "global"
+    @key_ring_id   = "#{@project_id}_key_ring_#{Time.now.to_i}"
     @crypto_key_id = "#{@project_id}_crypto_key_#{Time.now.to_i}"
-    @location     = "global"
 
     @test_key_ring = create_test_key_ring project_id: @project_id,
-        key_ring_id: @key_ring_id, location: @location
+        location_id: @location_id, key_ring_id: @key_ring_id
 
     @test_crypto_key = create_test_crypto_key project_id: @project_id,
-        key_ring_id: @key_ring_id, crypto_key: @crypto_key_id, location: @location
+        location_id: @location_id, key_ring_id: @key_ring_id,
+        crypto_key: @crypto_key_id
 
     @input_file = File.expand_path "resources/file.txt", __dir__
 
@@ -299,15 +300,15 @@ describe "Key Management Service" do
     expect {
       $create_key_ring.call(
         project_id: @project_id,
-        key_ring_id: key_ring_id,
-        location: @location
+        location_id: @location_id,
+        key_ring_id: key_ring_id
       )
     }.to output(/#{key_ring_id}/).to_stdout
 
     test_key_ring = get_test_key_ring(
       project_id: @project_id,
-      key_ring_id: key_ring_id,
-      location: @location
+      location_id: @location_id,
+      key_ring_id: key_ring_id
     )
 
     expect(test_key_ring.name).to match /#{key_ring_id}/
@@ -319,17 +320,17 @@ describe "Key Management Service" do
     expect {
       $create_crypto_key.call(
         project_id: @project_id,
+        location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_crypto_key_id,
-        location: @location
+        crypto_key: test_crypto_key_id
       )
     }.to output(/#{test_crypto_key_id}/).to_stdout
 
     test_crypto_key = get_test_crypto_key(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     expect(test_crypto_key.name).to match /#{test_crypto_key_id}/
@@ -341,9 +342,9 @@ describe "Key Management Service" do
     expect {
       $encrypt.call(
         project_id: @project_id,
+        location_id: @location_id,
         key_ring_id: @key_ring_id,
         crypto_key: @crypto_key_id,
-        location: @location,
         input_file: @input_file,
         output_file: temp_output.path
       )
@@ -351,9 +352,9 @@ describe "Key Management Service" do
 
     decrypt_test_file(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
       crypto_key: @crypto_key_id,
-      location: @location,
       input_file: temp_output.path,
       output_file: temp_output.path
     )
@@ -368,9 +369,9 @@ describe "Key Management Service" do
 
     encrypt_test_file(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
       crypto_key: @crypto_key_id,
-      location: @location,
       input_file: @input_file,
       output_file: temp_output.path
     )
@@ -378,9 +379,9 @@ describe "Key Management Service" do
     expect {
       $decrypt.call(
         project_id: @project_id,
+        location_id: @location_id,
         key_ring_id: @key_ring_id,
         crypto_key: @crypto_key_id,
-        location: @location,
         input_file: temp_output.path,
         output_file: temp_output.path
       )
@@ -396,32 +397,32 @@ describe "Key Management Service" do
 
     create_test_crypto_key(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     before_version_list = list_test_crypto_key_version(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     expect {
       $create_crypto_key_version.call(
         project_id: @project_id,
+        location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_crypto_key_id,
-        location: @location
+        crypto_key: test_crypto_key_id
       )
     }.to output(/Created version/).to_stdout
 
     after_version_list = list_test_crypto_key_version(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     expect(after_version_list.total_size).to be > before_version_list.total_size
@@ -432,16 +433,16 @@ describe "Key Management Service" do
 
     create_test_crypto_key(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     crypto_key_version = create_test_crypto_key_version(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     version = crypto_key_version.name.split("/").last
@@ -449,18 +450,18 @@ describe "Key Management Service" do
     expect {
       $set_crypto_key_primary_version.call(
         project_id: @project_id,
+        location_id: @location_id,
         key_ring_id: @key_ring_id,
         crypto_key: test_crypto_key_id,
-        version: version,
-        location: @location
+        version: version
       )
     }.to output(/Set #{version} as primary version/).to_stdout
 
     crypto_key = get_test_crypto_key(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     expect(crypto_key.primary.name).to eq crypto_key_version.name
@@ -471,19 +472,19 @@ describe "Key Management Service" do
 
     crypto_key = create_test_crypto_key(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     version = "1" # first version is labeled 1
 
     disabled_crypto_key_version = disable_test_crypto_key_version(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
       crypto_key: test_crypto_key_id,
-      version: version,
-      location: @location
+      version: version
     )
 
     expect(disabled_crypto_key_version.state).to eq "DISABLED"
@@ -491,19 +492,19 @@ describe "Key Management Service" do
     expect {
       $enable_crypto_key_version.call(
         project_id: @project_id,
+        location_id: @location_id,
         key_ring_id: @key_ring_id,
         crypto_key: test_crypto_key_id,
-        version: version,
-        location: @location
+        version: version
       )
     }.to output(/Enabled version #{version} of #{test_crypto_key_id}/).to_stdout
 
     crypto_key = get_test_crypto_key_version(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
       crypto_key: test_crypto_key_id,
-      version: version,
-      location: @location
+      version: version
     )
 
     expect(crypto_key.state).to eq "ENABLED"
@@ -514,9 +515,9 @@ describe "Key Management Service" do
 
     crypto_key = create_test_crypto_key(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     version = "1" # first version is labeled 1
@@ -524,19 +525,19 @@ describe "Key Management Service" do
     expect {
       $disable_crypto_key_version.call(
         project_id: @project_id,
+        location_id: @location_id,
         key_ring_id: @key_ring_id,
         crypto_key: test_crypto_key_id,
-        version: version,
-        location: @location
+        version: version
       )
     }.to output(/Disabled version #{version} of #{test_crypto_key_id}/).to_stdout
 
     crypto_key = get_test_crypto_key_version(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
       crypto_key: test_crypto_key_id,
-      version: version,
-      location: @location
+      version: version
     )
 
     expect(crypto_key.state).to eq "DISABLED"
@@ -547,19 +548,19 @@ describe "Key Management Service" do
 
     crypto_key = create_test_crypto_key(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     version = "1" # first version is labeled 1
 
     scheduled_crypto_key_version = destroy_test_crypto_key_version(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
       crypto_key: test_crypto_key_id,
-      version: version,
-      location: @location
+      version: version
     )
 
     expect(scheduled_crypto_key_version.state).to eq "DESTROY_SCHEDULED"
@@ -567,19 +568,19 @@ describe "Key Management Service" do
     expect {
       $restore_crypto_key_version.call(
         project_id: @project_id,
+        location_id: @location_id,
         key_ring_id: @key_ring_id,
         crypto_key: test_crypto_key_id,
-        version: version,
-        location: @location
+        version: version
       )
     }.to output(/Restored version #{version} of #{test_crypto_key_id}/).to_stdout
 
     crypto_key = get_test_crypto_key_version(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
       crypto_key: test_crypto_key_id,
-      version: version,
-      location: @location
+      version: version
     )
 
     expect(crypto_key.state).to eq "DISABLED"
@@ -590,9 +591,9 @@ describe "Key Management Service" do
 
     crypto_key = create_test_crypto_key(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     version = "1" # first version is labeled 1
@@ -600,19 +601,19 @@ describe "Key Management Service" do
     expect {
       $destroy_crypto_key_version.call(
         project_id: @project_id,
+        location_id: @location_id,
         key_ring_id: @key_ring_id,
         crypto_key: test_crypto_key_id,
-        version: version,
-        location: @location
+        version: version
       )
     }.to output(/Destroyed version #{version} of #{test_crypto_key_id}/).to_stdout
 
     crypto_key = get_test_crypto_key_version(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
       crypto_key: test_crypto_key_id,
-      version: version,
-      location: @location
+      version: version
     )
 
     expect(crypto_key.state).to eq "DESTROY_SCHEDULED"
@@ -622,19 +623,19 @@ describe "Key Management Service" do
     expect {
       $add_member_to_crypto_key_policy.call(
         project_id: @project_id,
+        location_id: @location_id,
         key_ring_id: @key_ring_id,
         crypto_key: @crypto_key_id,
         member: "user:test@test.com",
-        role: "roles/owner",
-        location: @location
+        role: "roles/owner"
       )
     }.to output(/test@test.com/).to_stdout
 
     policy = get_test_crypto_key_policy(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: @crypto_key_id,
-      location: @location
+      crypto_key: @crypto_key_id
     )
 
     members = policy.bindings.map(&:members).flatten
@@ -647,25 +648,25 @@ describe "Key Management Service" do
 
     create_test_crypto_key(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     add_test_member_to_crypto_key_policy(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
       crypto_key: test_crypto_key_id,
       member: "user:test@test.com",
-      role: "roles/owner",
-      location: @location
+      role: "roles/owner"
     )
 
     policy = get_test_crypto_key_policy(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     expect(policy.bindings).to_not be nil
@@ -673,19 +674,19 @@ describe "Key Management Service" do
     expect {
       $remove_member_from_crypto_key_policy.call(
         project_id: @project_id,
+        location_id: @location_id,
         key_ring_id: @key_ring_id,
         crypto_key: test_crypto_key_id,
         member: "user:test@test.com",
-        role: "roles/owner",
-        location: @location
+        role: "roles/owner"
       )
     }.to output(/test@test.com/).to_stdout
 
     policy = get_test_crypto_key_policy(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      location: @location
+      crypto_key: test_crypto_key_id
     )
 
     if policy.bindings
@@ -698,16 +699,16 @@ describe "Key Management Service" do
   it "can add a member to a key ring policy" do
     remove_test_member_to_key_ring_policy(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
       member: "serviceAccount:test-account@#{@project_id}.iam.gserviceaccount.com",
-      role: "roles/owner",
-      location: @location
+      role: "roles/owner"
     )
 
     policy = get_test_key_ring_policy(
       project_id: @project_id,
-      key_ring_id: @key_ring_id,
-      location: @location
+      location_id: @location_id,
+      key_ring_id: @key_ring_id
     )
 
     if policy.bindings
@@ -719,17 +720,17 @@ describe "Key Management Service" do
     expect {
       $add_member_to_key_ring_policy.call(
         project_id: @project_id,
+        location_id: @location_id,
         key_ring_id: @key_ring_id,
         member: "serviceAccount:test-account@#{@project_id}.iam.gserviceaccount.com",
-        role: "roles/owner",
-        location: @location
+        role: "roles/owner"
       )
     }.to output(/serviceAccount:test-account@#{@project_id}.iam.gserviceaccount.com/).to_stdout
 
     policy = get_test_key_ring_policy(
       project_id: @project_id,
-      key_ring_id: @key_ring_id,
-      location: @location
+      location_id: @location_id,
+      key_ring_id: @key_ring_id
     )
 
     members = policy.bindings.map(&:members).flatten
@@ -740,17 +741,17 @@ describe "Key Management Service" do
   it "can get a key ring policy" do
     add_test_member_to_key_ring_policy(
       project_id: @project_id,
+      location_id: @location_id,
       key_ring_id: @key_ring_id,
       member: "serviceAccount:test-account@#{@project_id}.iam.gserviceaccount.com",
-      role: "roles/owner",
-      location: @location
+      role: "roles/owner"
     )
 
     expect {
       $get_key_ring_policy.call(
         project_id: @project_id,
-        key_ring_id: @key_ring_id,
-        location: @location
+        location_id: @location_id,
+        key_ring_id: @key_ring_id
       )
     }.to output(/serviceAccount:test-account@#{@project_id}.iam.gserviceaccount.com/).to_stdout
   end

--- a/kms/spec/kms_spec.rb
+++ b/kms/spec/kms_spec.rb
@@ -48,7 +48,7 @@ describe "Key Management Service" do
     kms_client.get_project_location_key_ring resource
   end
 
-  def create_test_crypto_key project_id:, location_id:, key_ring_id:, crypto_key:
+  def create_test_crypto_key project_id:, location_id:, key_ring_id:, crypto_key_id:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location_id}/" +
@@ -59,15 +59,15 @@ describe "Key Management Service" do
       Google::Apis::CloudkmsV1::CryptoKey.new(
         purpose: "ENCRYPT_DECRYPT"
       ),
-      crypto_key_id: crypto_key
+      crypto_key_id: crypto_key_id
     )
   end
 
-  def create_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key:
+  def create_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key_id:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location_id}/" +
-               "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+               "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
     crypto_key_version = kms_client.create_project_location_key_ring_crypto_key_crypto_key_version(
         resource,
@@ -75,13 +75,13 @@ describe "Key Management Service" do
     )
   end
 
-  def destroy_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key:, version:
+  def destroy_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key_id:, version_id:
     kms_client = create_service_client
 
     # The resource name of the location associated with the key ring
     resource = "projects/#{project_id}/locations/#{location_id}/" +
-               "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
-               "cryptoKeyVersions/#{version}"
+               "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}/" +
+               "cryptoKeyVersions/#{version_id}"
 
     # Destroy specific version of the crypto key
     kms_client.destroy_crypto_key_version(
@@ -90,12 +90,12 @@ describe "Key Management Service" do
     )
   end
 
-  def disable_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key:, version:
+  def disable_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key_id:, version_id:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location_id}/" +
-             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
-             "cryptoKeyVersions/#{version}"
+             "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}/" +
+             "cryptoKeyVersions/#{version_id}"
 
     # Get a version of the crypto key
     crypto_key_version = kms_client.get_project_location_key_ring_crypto_key_crypto_key_version resource
@@ -110,31 +110,31 @@ describe "Key Management Service" do
     )
   end
 
-  def get_test_crypto_key project_id:, location_id:, key_ring_id:, crypto_key:
+  def get_test_crypto_key project_id:, location_id:, key_ring_id:, crypto_key_id:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location_id}/" +
-               "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+               "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
     kms_client.get_project_location_key_ring_crypto_key resource
   end
 
-  def get_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key:, version:
+  def get_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key_id:, version_id:
 
     kms_client = create_service_client
 
     name = "projects/#{project_id}/locations/#{location_id}/" +
-           "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}/" +
-           "cryptoKeyVersions/#{version}"
+           "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}/" +
+           "cryptoKeyVersions/#{version_id}"
 
     kms_client.get_project_location_key_ring_crypto_key_crypto_key_version name
   end
 
-  def list_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key:
+  def list_test_crypto_key_version project_id:, location_id:, key_ring_id:, crypto_key_id:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location_id}/" +
-               "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+               "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
     kms_client.list_project_location_key_ring_crypto_key_crypto_key_versions(
         resource
@@ -149,11 +149,11 @@ describe "Key Management Service" do
     kms_client.list_project_location_key_rings resource
   end
 
-  def get_test_crypto_key_policy project_id:, location_id:, key_ring_id:, crypto_key:
+  def get_test_crypto_key_policy project_id:, location_id:, key_ring_id:, crypto_key_id:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location_id}/" +
-               "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+               "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
     kms_client.get_project_location_key_ring_crypto_key_iam_policy resource
   end
@@ -167,11 +167,11 @@ describe "Key Management Service" do
     kms_client.get_project_location_key_ring_iam_policy resource
   end
 
-  def add_test_member_to_crypto_key_policy project_id:, location_id:, key_ring_id:, crypto_key:, member:, role:
+  def add_test_member_to_crypto_key_policy project_id:, location_id:, key_ring_id:, crypto_key_id:, member:, role:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location_id}/" +
-               "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+               "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
     policy = kms_client.get_project_location_key_ring_crypto_key_iam_policy resource
 
@@ -239,11 +239,11 @@ describe "Key Management Service" do
     kms_client.set_key_ring_iam_policy resource, policy_request
   end
 
-  def encrypt_test_file project_id:, location_id:, key_ring_id:, crypto_key:, input_file:, output_file:
+  def encrypt_test_file project_id:, location_id:, key_ring_id:, crypto_key_id:, input_file:, output_file:
     kms_client = create_service_client
 
     name = "projects/#{project_id}/locations/#{location_id}/" +
-           "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+           "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
     plain_text = File.read input_file
 
@@ -256,11 +256,11 @@ describe "Key Management Service" do
     File.write output_file, response.ciphertext
   end
 
-  def decrypt_test_file project_id:, location_id:, key_ring_id:, crypto_key:, input_file:, output_file:
+  def decrypt_test_file project_id:, location_id:, key_ring_id:, crypto_key_id:, input_file:, output_file:
     kms_client = create_service_client
 
     name = "projects/#{project_id}/locations/#{location_id}/" +
-           "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key}"
+           "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
     encrypted_text = File.read input_file
 
@@ -284,7 +284,7 @@ describe "Key Management Service" do
 
     @test_crypto_key = create_test_crypto_key project_id: @project_id,
         location_id: @location_id, key_ring_id: @key_ring_id,
-        crypto_key: @crypto_key_id
+        crypto_key_id: @crypto_key_id
 
     @input_file = File.expand_path "resources/file.txt", __dir__
 
@@ -322,7 +322,7 @@ describe "Key Management Service" do
         project_id: @project_id,
         location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_crypto_key_id
+        crypto_key_id: test_crypto_key_id
       )
     }.to output(/#{test_crypto_key_id}/).to_stdout
 
@@ -330,7 +330,7 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
     expect(test_crypto_key.name).to match /#{test_crypto_key_id}/
@@ -344,7 +344,7 @@ describe "Key Management Service" do
         project_id: @project_id,
         location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: @crypto_key_id,
+        crypto_key_id: @crypto_key_id,
         input_file: @input_file,
         output_file: temp_output.path
       )
@@ -354,7 +354,7 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: @crypto_key_id,
+      crypto_key_id: @crypto_key_id,
       input_file: temp_output.path,
       output_file: temp_output.path
     )
@@ -371,7 +371,7 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: @crypto_key_id,
+      crypto_key_id: @crypto_key_id,
       input_file: @input_file,
       output_file: temp_output.path
     )
@@ -381,7 +381,7 @@ describe "Key Management Service" do
         project_id: @project_id,
         location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: @crypto_key_id,
+        crypto_key_id: @crypto_key_id,
         input_file: temp_output.path,
         output_file: temp_output.path
       )
@@ -399,14 +399,14 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
     before_version_list = list_test_crypto_key_version(
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
     expect {
@@ -414,7 +414,7 @@ describe "Key Management Service" do
         project_id: @project_id,
         location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_crypto_key_id
+        crypto_key_id: test_crypto_key_id
       )
     }.to output(/Created version/).to_stdout
 
@@ -422,7 +422,7 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
     expect(after_version_list.total_size).to be > before_version_list.total_size
@@ -435,33 +435,33 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
     crypto_key_version = create_test_crypto_key_version(
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
-    version = crypto_key_version.name.split("/").last
+    version_id = crypto_key_version.name.split("/").last
 
     expect {
       $set_crypto_key_primary_version.call(
         project_id: @project_id,
         location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_crypto_key_id,
-        version: version
+        crypto_key_id: test_crypto_key_id,
+        version_id: version_id
       )
-    }.to output(/Set #{version} as primary version/).to_stdout
+    }.to output(/Set #{version_id} as primary version/).to_stdout
 
     crypto_key = get_test_crypto_key(
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
     expect(crypto_key.primary.name).to eq crypto_key_version.name
@@ -474,17 +474,17 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
-    version = "1" # first version is labeled 1
+    version_id = "1" # first version is labeled 1
 
     disabled_crypto_key_version = disable_test_crypto_key_version(
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      version: version
+      crypto_key_id: test_crypto_key_id,
+      version_id: version_id
     )
 
     expect(disabled_crypto_key_version.state).to eq "DISABLED"
@@ -494,17 +494,17 @@ describe "Key Management Service" do
         project_id: @project_id,
         location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_crypto_key_id,
-        version: version
+        crypto_key_id: test_crypto_key_id,
+        version_id: version_id
       )
-    }.to output(/Enabled version #{version} of #{test_crypto_key_id}/).to_stdout
+    }.to output(/Enabled version #{version_id} of #{test_crypto_key_id}/).to_stdout
 
     crypto_key = get_test_crypto_key_version(
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      version: version
+      crypto_key_id: test_crypto_key_id,
+      version_id: version_id
     )
 
     expect(crypto_key.state).to eq "ENABLED"
@@ -517,27 +517,27 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
-    version = "1" # first version is labeled 1
+    version_id = "1" # first version is labeled 1
 
     expect {
       $disable_crypto_key_version.call(
         project_id: @project_id,
         location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_crypto_key_id,
-        version: version
+        crypto_key_id: test_crypto_key_id,
+        version_id: version_id
       )
-    }.to output(/Disabled version #{version} of #{test_crypto_key_id}/).to_stdout
+    }.to output(/Disabled version #{version_id} of #{test_crypto_key_id}/).to_stdout
 
     crypto_key = get_test_crypto_key_version(
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      version: version
+      crypto_key_id: test_crypto_key_id,
+      version_id: version_id
     )
 
     expect(crypto_key.state).to eq "DISABLED"
@@ -550,17 +550,17 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
-    version = "1" # first version is labeled 1
+    version_id = "1" # first version is labeled 1
 
     scheduled_crypto_key_version = destroy_test_crypto_key_version(
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      version: version
+      crypto_key_id: test_crypto_key_id,
+      version_id: version_id
     )
 
     expect(scheduled_crypto_key_version.state).to eq "DESTROY_SCHEDULED"
@@ -570,17 +570,17 @@ describe "Key Management Service" do
         project_id: @project_id,
         location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_crypto_key_id,
-        version: version
+        crypto_key_id: test_crypto_key_id,
+        version_id: version_id
       )
-    }.to output(/Restored version #{version} of #{test_crypto_key_id}/).to_stdout
+    }.to output(/Restored version #{version_id} of #{test_crypto_key_id}/).to_stdout
 
     crypto_key = get_test_crypto_key_version(
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      version: version
+      crypto_key_id: test_crypto_key_id,
+      version_id: version_id
     )
 
     expect(crypto_key.state).to eq "DISABLED"
@@ -593,27 +593,27 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
-    version = "1" # first version is labeled 1
+    version_id = "1" # first version is labeled 1
 
     expect {
       $destroy_crypto_key_version.call(
         project_id: @project_id,
         location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_crypto_key_id,
-        version: version
+        crypto_key_id: test_crypto_key_id,
+        version_id: version_id
       )
-    }.to output(/Destroyed version #{version} of #{test_crypto_key_id}/).to_stdout
+    }.to output(/Destroyed version #{version_id} of #{test_crypto_key_id}/).to_stdout
 
     crypto_key = get_test_crypto_key_version(
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
-      version: version
+      crypto_key_id: test_crypto_key_id,
+      version_id: version_id
     )
 
     expect(crypto_key.state).to eq "DESTROY_SCHEDULED"
@@ -625,7 +625,7 @@ describe "Key Management Service" do
         project_id: @project_id,
         location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: @crypto_key_id,
+        crypto_key_id: @crypto_key_id,
         member: "user:test@test.com",
         role: "roles/owner"
       )
@@ -635,7 +635,7 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: @crypto_key_id
+      crypto_key_id: @crypto_key_id
     )
 
     members = policy.bindings.map(&:members).flatten
@@ -650,14 +650,14 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
     add_test_member_to_crypto_key_policy(
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id,
+      crypto_key_id: test_crypto_key_id,
       member: "user:test@test.com",
       role: "roles/owner"
     )
@@ -666,7 +666,7 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
     expect(policy.bindings).to_not be nil
@@ -676,7 +676,7 @@ describe "Key Management Service" do
         project_id: @project_id,
         location_id: @location_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_crypto_key_id,
+        crypto_key_id: test_crypto_key_id,
         member: "user:test@test.com",
         role: "roles/owner"
       )
@@ -686,7 +686,7 @@ describe "Key Management Service" do
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_crypto_key_id
+      crypto_key_id: test_crypto_key_id
     )
 
     if policy.bindings

--- a/kms/spec/kms_spec.rb
+++ b/kms/spec/kms_spec.rb
@@ -27,7 +27,7 @@ describe "Key Management Service" do
     kms_client
   end
 
-  def create_test_keyring project_id:, key_ring_id:, location:
+  def create_test_key_ring project_id:, key_ring_id:, location:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location}"
@@ -39,7 +39,7 @@ describe "Key Management Service" do
     )
   end
 
-  def get_test_keyring project_id:, key_ring_id:, location:
+  def get_test_key_ring project_id:, key_ring_id:, location:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location}/" +
@@ -48,7 +48,7 @@ describe "Key Management Service" do
     kms_client.get_project_location_key_ring resource
   end
 
-  def create_test_cryptokey project_id:, key_ring_id:, crypto_key:, location:
+  def create_test_crypto_key project_id:, key_ring_id:, crypto_key:, location:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location}/" +
@@ -63,7 +63,7 @@ describe "Key Management Service" do
     )
   end
 
-  def create_test_cryptokey_version project_id:, key_ring_id:, crypto_key:, location:
+  def create_test_crypto_key_version project_id:, key_ring_id:, crypto_key:, location:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location}/" +
@@ -75,7 +75,7 @@ describe "Key Management Service" do
     )
   end
 
-  def destroy_test_cryptokey_version project_id:, key_ring_id:, crypto_key:, version:, location:
+  def destroy_test_crypto_key_version project_id:, key_ring_id:, crypto_key:, version:, location:
     kms_client = create_service_client
 
     # The resource name of the location associated with the key ring
@@ -90,7 +90,7 @@ describe "Key Management Service" do
     )
   end
 
-  def disable_test_cryptokey_version project_id:, key_ring_id:, crypto_key:, version:, location:
+  def disable_test_crypto_key_version project_id:, key_ring_id:, crypto_key:, version:, location:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location}/" +
@@ -110,7 +110,7 @@ describe "Key Management Service" do
     )
   end
 
-  def get_test_cryptokey project_id:, key_ring_id:, crypto_key:, location:
+  def get_test_crypto_key project_id:, key_ring_id:, crypto_key:, location:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location}/" +
@@ -119,7 +119,7 @@ describe "Key Management Service" do
     kms_client.get_project_location_key_ring_crypto_key resource
   end
 
-  def get_test_cryptokey_version project_id:, key_ring_id:, crypto_key:, version:, location:
+  def get_test_crypto_key_version project_id:, key_ring_id:, crypto_key:, version:, location:
 
     kms_client = create_service_client
 
@@ -130,7 +130,7 @@ describe "Key Management Service" do
     kms_client.get_project_location_key_ring_crypto_key_crypto_key_version name
   end
 
-  def list_test_cryptokey_version project_id:, key_ring_id:, crypto_key:, location:
+  def list_test_crypto_key_version project_id:, key_ring_id:, crypto_key:, location:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location}/" +
@@ -149,7 +149,7 @@ describe "Key Management Service" do
     kms_client.list_project_location_key_rings resource
   end
 
-  def get_test_cryptokey_policy project_id:, key_ring_id:, crypto_key:, location:
+  def get_test_crypto_key_policy project_id:, key_ring_id:, crypto_key:, location:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location}/" +
@@ -158,7 +158,7 @@ describe "Key Management Service" do
     kms_client.get_project_location_key_ring_crypto_key_iam_policy resource
   end
 
-  def get_test_keyring_policy project_id:, key_ring_id:, location:
+  def get_test_key_ring_policy project_id:, key_ring_id:, location:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location}/" +
@@ -167,7 +167,7 @@ describe "Key Management Service" do
     kms_client.get_project_location_key_ring_iam_policy resource
   end
 
-  def add_test_member_to_cryptokey_policy project_id:, key_ring_id:, crypto_key:, member:, role:, location:
+  def add_test_member_to_crypto_key_policy project_id:, key_ring_id:, crypto_key:, member:, role:, location:
     kms_client = create_service_client
 
     resource = "projects/#{project_id}/locations/#{location}/" +
@@ -188,10 +188,10 @@ describe "Key Management Service" do
     kms_client.set_crypto_key_iam_policy resource, policy_request
   end
 
-  def add_test_member_to_keyring_policy project_id:, key_ring_id:, member:, role:, location:
+  def add_test_member_to_key_ring_policy project_id:, key_ring_id:, member:, role:, location:
     kms_client = create_service_client
 
-    policy = get_test_keyring_policy(
+    policy = get_test_key_ring_policy(
       project_id: project_id,
       key_ring_id: key_ring_id,
       location: location
@@ -214,10 +214,10 @@ describe "Key Management Service" do
     kms_client.set_key_ring_iam_policy resource, policy_request
   end
 
-  def remove_test_member_to_keyring_policy project_id:, key_ring_id:, member:, role:, location:
+  def remove_test_member_to_key_ring_policy project_id:, key_ring_id:, member:, role:, location:
     kms_client = create_service_client
 
-    policy = get_test_keyring_policy(
+    policy = get_test_key_ring_policy(
       project_id: project_id,
       key_ring_id: key_ring_id,
       location: location
@@ -276,14 +276,14 @@ describe "Key Management Service" do
   before :all do
     @project_id   = ENV["GOOGLE_CLOUD_PROJECT"]
     @key_ring_id  = "#{@project_id}_key_ring_#{Time.now.to_i}"
-    @cryptokey_id = "#{@project_id}_cryptokey_#{Time.now.to_i}"
+    @crypto_key_id = "#{@project_id}_crypto_key_#{Time.now.to_i}"
     @location     = "global"
 
-    @test_key_ring = create_test_keyring project_id: @project_id,
+    @test_key_ring = create_test_key_ring project_id: @project_id,
         key_ring_id: @key_ring_id, location: @location
 
-    @test_cryptokey = create_test_cryptokey project_id: @project_id,
-        key_ring_id: @key_ring_id, crypto_key: @cryptokey_id, location: @location
+    @test_crypto_key = create_test_crypto_key project_id: @project_id,
+        key_ring_id: @key_ring_id, crypto_key: @crypto_key_id, location: @location
 
     @input_file = File.expand_path "resources/file.txt", __dir__
 
@@ -297,14 +297,14 @@ describe "Key Management Service" do
     key_ring_id = "#{@project_id}-create-#{Time.now.to_i}"
 
     expect {
-      $create_keyring.call(
+      $create_key_ring.call(
         project_id: @project_id,
         key_ring_id: key_ring_id,
         location: @location
       )
     }.to output(/#{key_ring_id}/).to_stdout
 
-    test_key_ring = get_test_keyring(
+    test_key_ring = get_test_key_ring(
       project_id: @project_id,
       key_ring_id: key_ring_id,
       location: @location
@@ -314,25 +314,25 @@ describe "Key Management Service" do
   end
 
   it "can create a crypto key" do
-    test_cryptokey_id = "#{@project_id}-crypto-#{Time.now.to_i}"
+    test_crypto_key_id = "#{@project_id}-crypto-#{Time.now.to_i}"
 
     expect {
-      $create_cryptokey.call(
+      $create_crypto_key.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_cryptokey_id,
+        crypto_key: test_crypto_key_id,
         location: @location
       )
-    }.to output(/#{test_cryptokey_id}/).to_stdout
+    }.to output(/#{test_crypto_key_id}/).to_stdout
 
-    test_crypto_key = get_test_cryptokey(
+    test_crypto_key = get_test_crypto_key(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
-    expect(test_crypto_key.name).to match /#{test_cryptokey_id}/
+    expect(test_crypto_key.name).to match /#{test_crypto_key_id}/
   end
 
   it "can encrypt a file" do
@@ -342,7 +342,7 @@ describe "Key Management Service" do
       $encrypt.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
-        crypto_key: @cryptokey_id,
+        crypto_key: @crypto_key_id,
         location: @location,
         input_file: @input_file,
         output_file: temp_output.path
@@ -352,7 +352,7 @@ describe "Key Management Service" do
     decrypt_test_file(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: @cryptokey_id,
+      crypto_key: @crypto_key_id,
       location: @location,
       input_file: temp_output.path,
       output_file: temp_output.path
@@ -369,7 +369,7 @@ describe "Key Management Service" do
     encrypt_test_file(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: @cryptokey_id,
+      crypto_key: @crypto_key_id,
       location: @location,
       input_file: @input_file,
       output_file: temp_output.path
@@ -379,7 +379,7 @@ describe "Key Management Service" do
       $decrypt.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
-        crypto_key: @cryptokey_id,
+        crypto_key: @crypto_key_id,
         location: @location,
         input_file: temp_output.path,
         output_file: temp_output.path
@@ -392,35 +392,35 @@ describe "Key Management Service" do
   end
 
   it "can create a crypto key version" do
-    test_cryptokey_id = "#{@project_id}-version-#{Time.now.to_i}"
+    test_crypto_key_id = "#{@project_id}-version-#{Time.now.to_i}"
 
-    create_test_cryptokey(
+    create_test_crypto_key(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
-    before_version_list = list_test_cryptokey_version(
+    before_version_list = list_test_crypto_key_version(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
     expect {
-      $create_cryptokey_version.call(
+      $create_crypto_key_version.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_cryptokey_id,
+        crypto_key: test_crypto_key_id,
         location: @location
       )
     }.to output(/Created version/).to_stdout
 
-    after_version_list = list_test_cryptokey_version(
+    after_version_list = list_test_crypto_key_version(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
@@ -428,212 +428,212 @@ describe "Key Management Service" do
   end
 
   it "can set a crypto key version as the primary version" do
-    test_cryptokey_id = "#{@project_id}-primary-#{Time.now.to_i}"
+    test_crypto_key_id = "#{@project_id}-primary-#{Time.now.to_i}"
 
-    create_test_cryptokey(
+    create_test_crypto_key(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
-    cryptokey_version = create_test_cryptokey_version(
+    crypto_key_version = create_test_crypto_key_version(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
-    version = cryptokey_version.name.split("/").last
+    version = crypto_key_version.name.split("/").last
 
     expect {
-      $set_cryptokey_primary_version.call(
+      $set_crypto_key_primary_version.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_cryptokey_id,
+        crypto_key: test_crypto_key_id,
         version: version,
         location: @location
       )
     }.to output(/Set #{version} as primary version/).to_stdout
 
-    cryptokey = get_test_cryptokey(
+    crypto_key = get_test_crypto_key(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
-    expect(cryptokey.primary.name).to eq cryptokey_version.name
+    expect(crypto_key.primary.name).to eq crypto_key_version.name
   end
 
   it "can enable a crypto key version" do
-    test_cryptokey_id = "#{@project_id}-enable-#{Time.now.to_i}"
+    test_crypto_key_id = "#{@project_id}-enable-#{Time.now.to_i}"
 
-    cryptokey = create_test_cryptokey(
+    crypto_key = create_test_crypto_key(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
     version = "1" # first version is labeled 1
 
-    disabled_cryptokey_version = disable_test_cryptokey_version(
+    disabled_crypto_key_version = disable_test_crypto_key_version(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       version: version,
       location: @location
     )
 
-    expect(disabled_cryptokey_version.state).to eq "DISABLED"
+    expect(disabled_crypto_key_version.state).to eq "DISABLED"
 
     expect {
-      $enable_cryptokey_version.call(
+      $enable_crypto_key_version.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_cryptokey_id,
+        crypto_key: test_crypto_key_id,
         version: version,
         location: @location
       )
-    }.to output(/Enabled version #{version} of #{test_cryptokey_id}/).to_stdout
+    }.to output(/Enabled version #{version} of #{test_crypto_key_id}/).to_stdout
 
-    cryptokey = get_test_cryptokey_version(
+    crypto_key = get_test_crypto_key_version(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       version: version,
       location: @location
     )
 
-    expect(cryptokey.state).to eq "ENABLED"
+    expect(crypto_key.state).to eq "ENABLED"
   end
 
   it "can disable a crypto key version" do
-    test_cryptokey_id = "#{@project_id}-disable-#{Time.now.to_i}"
+    test_crypto_key_id = "#{@project_id}-disable-#{Time.now.to_i}"
 
-    cryptokey = create_test_cryptokey(
+    crypto_key = create_test_crypto_key(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
     version = "1" # first version is labeled 1
 
     expect {
-      $disable_cryptokey_version.call(
+      $disable_crypto_key_version.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_cryptokey_id,
+        crypto_key: test_crypto_key_id,
         version: version,
         location: @location
       )
-    }.to output(/Disabled version #{version} of #{test_cryptokey_id}/).to_stdout
+    }.to output(/Disabled version #{version} of #{test_crypto_key_id}/).to_stdout
 
-    cryptokey = get_test_cryptokey_version(
+    crypto_key = get_test_crypto_key_version(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       version: version,
       location: @location
     )
 
-    expect(cryptokey.state).to eq "DISABLED"
+    expect(crypto_key.state).to eq "DISABLED"
   end
 
   it "can restore a crypto key version" do
-    test_cryptokey_id = "#{@project_id}-restore-#{Time.now.to_i}"
+    test_crypto_key_id = "#{@project_id}-restore-#{Time.now.to_i}"
 
-    cryptokey = create_test_cryptokey(
+    crypto_key = create_test_crypto_key(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
     version = "1" # first version is labeled 1
 
-    scheduled_cryptokey_version = destroy_test_cryptokey_version(
+    scheduled_crypto_key_version = destroy_test_crypto_key_version(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       version: version,
       location: @location
     )
 
-    expect(scheduled_cryptokey_version.state).to eq "DESTROY_SCHEDULED"
+    expect(scheduled_crypto_key_version.state).to eq "DESTROY_SCHEDULED"
 
     expect {
-      $restore_cryptokey_version.call(
+      $restore_crypto_key_version.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_cryptokey_id,
+        crypto_key: test_crypto_key_id,
         version: version,
         location: @location
       )
-    }.to output(/Restored version #{version} of #{test_cryptokey_id}/).to_stdout
+    }.to output(/Restored version #{version} of #{test_crypto_key_id}/).to_stdout
 
-    cryptokey = get_test_cryptokey_version(
+    crypto_key = get_test_crypto_key_version(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       version: version,
       location: @location
     )
 
-    expect(cryptokey.state).to eq "DISABLED"
+    expect(crypto_key.state).to eq "DISABLED"
   end
 
   it "can destroy a crypto key version" do
-    test_cryptokey_id = "#{@project_id}-destroy-#{Time.now.to_i}"
+    test_crypto_key_id = "#{@project_id}-destroy-#{Time.now.to_i}"
 
-    cryptokey = create_test_cryptokey(
+    crypto_key = create_test_crypto_key(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
     version = "1" # first version is labeled 1
 
     expect {
-      $destroy_cryptokey_version.call(
+      $destroy_crypto_key_version.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_cryptokey_id,
+        crypto_key: test_crypto_key_id,
         version: version,
         location: @location
       )
-    }.to output(/Destroyed version #{version} of #{test_cryptokey_id}/).to_stdout
+    }.to output(/Destroyed version #{version} of #{test_crypto_key_id}/).to_stdout
 
-    cryptokey = get_test_cryptokey_version(
+    crypto_key = get_test_crypto_key_version(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       version: version,
       location: @location
     )
 
-    expect(cryptokey.state).to eq "DESTROY_SCHEDULED"
+    expect(crypto_key.state).to eq "DESTROY_SCHEDULED"
   end
 
   it "can add a member to a crypto key policy" do
     expect {
-      $add_member_to_cryptokey_policy.call(
+      $add_member_to_crypto_key_policy.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
-        crypto_key: @cryptokey_id,
+        crypto_key: @crypto_key_id,
         member: "user:test@test.com",
         role: "roles/owner",
         location: @location
       )
     }.to output(/test@test.com/).to_stdout
 
-    policy = get_test_cryptokey_policy(
+    policy = get_test_crypto_key_policy(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: @cryptokey_id,
+      crypto_key: @crypto_key_id,
       location: @location
     )
 
@@ -643,48 +643,48 @@ describe "Key Management Service" do
   end
 
   it "can remove a member to a crypto key policy" do
-    test_cryptokey_id = "#{@project_id}-remove-member-#{Time.now.to_i}"
+    test_crypto_key_id = "#{@project_id}-remove-member-#{Time.now.to_i}"
 
-    create_test_cryptokey(
+    create_test_crypto_key(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
-    add_test_member_to_cryptokey_policy(
+    add_test_member_to_crypto_key_policy(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       member: "user:test@test.com",
       role: "roles/owner",
       location: @location
     )
 
-    policy = get_test_cryptokey_policy(
+    policy = get_test_crypto_key_policy(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
     expect(policy.bindings).to_not be nil
 
     expect {
-      $remove_member_from_cryptokey_policy.call(
+      $remove_member_from_crypto_key_policy.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
-        crypto_key: test_cryptokey_id,
+        crypto_key: test_crypto_key_id,
         member: "user:test@test.com",
         role: "roles/owner",
         location: @location
       )
     }.to output(/test@test.com/).to_stdout
 
-    policy = get_test_cryptokey_policy(
+    policy = get_test_crypto_key_policy(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
-      crypto_key: test_cryptokey_id,
+      crypto_key: test_crypto_key_id,
       location: @location
     )
 
@@ -696,7 +696,7 @@ describe "Key Management Service" do
   end
 
   it "can add a member to a key ring policy" do
-    remove_test_member_to_keyring_policy(
+    remove_test_member_to_key_ring_policy(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
       member: "serviceAccount:test-account@#{@project_id}.iam.gserviceaccount.com",
@@ -704,7 +704,7 @@ describe "Key Management Service" do
       location: @location
     )
 
-    policy = get_test_keyring_policy(
+    policy = get_test_key_ring_policy(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
       location: @location
@@ -717,7 +717,7 @@ describe "Key Management Service" do
     end
 
     expect {
-      $add_member_to_keyring_policy.call(
+      $add_member_to_key_ring_policy.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
         member: "serviceAccount:test-account@#{@project_id}.iam.gserviceaccount.com",
@@ -726,7 +726,7 @@ describe "Key Management Service" do
       )
     }.to output(/serviceAccount:test-account@#{@project_id}.iam.gserviceaccount.com/).to_stdout
 
-    policy = get_test_keyring_policy(
+    policy = get_test_key_ring_policy(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
       location: @location
@@ -738,7 +738,7 @@ describe "Key Management Service" do
   end
 
   it "can get a key ring policy" do
-    add_test_member_to_keyring_policy(
+    add_test_member_to_key_ring_policy(
       project_id: @project_id,
       key_ring_id: @key_ring_id,
       member: "serviceAccount:test-account@#{@project_id}.iam.gserviceaccount.com",
@@ -747,7 +747,7 @@ describe "Key Management Service" do
     )
 
     expect {
-      $get_keyring_policy.call(
+      $get_key_ring_policy.call(
         project_id: @project_id,
         key_ring_id: @key_ring_id,
         location: @location

--- a/kms/spec/kms_spec.rb
+++ b/kms/spec/kms_spec.rb
@@ -239,38 +239,38 @@ describe "Key Management Service" do
     kms_client.set_key_ring_iam_policy resource, policy_request
   end
 
-  def encrypt_test_file project_id:, location_id:, key_ring_id:, crypto_key_id:, input_file:, output_file:
+  def encrypt_test_file project_id:, location_id:, key_ring_id:, crypto_key_id:, plaintext_file:, ciphertext_file:
     kms_client = create_service_client
 
     name = "projects/#{project_id}/locations/#{location_id}/" +
            "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
-    plain_text = File.read input_file
+    plaintext = File.read plaintext_file
 
     request = Google::Apis::CloudkmsV1::EncryptRequest.new(
-      plaintext: plain_text
+      plaintext: plaintext
     )
 
     response = kms_client.encrypt_crypto_key name, request
 
-    File.write output_file, response.ciphertext
+    File.write ciphertext_file, response.ciphertext
   end
 
-  def decrypt_test_file project_id:, location_id:, key_ring_id:, crypto_key_id:, input_file:, output_file:
+  def decrypt_test_file project_id:, location_id:, key_ring_id:, crypto_key_id:, ciphertext_file:, plaintext_file:
     kms_client = create_service_client
 
     name = "projects/#{project_id}/locations/#{location_id}/" +
            "keyRings/#{key_ring_id}/cryptoKeys/#{crypto_key_id}"
 
-    encrypted_text = File.read input_file
+    ciphertext = File.read ciphertext_file
 
     request = Google::Apis::CloudkmsV1::DecryptRequest.new(
-      ciphertext: encrypted_text
+      ciphertext: ciphertext
     )
 
     response = kms_client.decrypt_crypto_key name, request
 
-    File.write output_file, response.plaintext
+    File.write plaintext_file, response.plaintext
   end
 
   before :all do
@@ -286,7 +286,7 @@ describe "Key Management Service" do
         location_id: @location_id, key_ring_id: @key_ring_id,
         crypto_key_id: @crypto_key_id
 
-    @input_file = File.expand_path "resources/file.txt", __dir__
+    @plaintext_file = File.expand_path "resources/file.txt", __dir__
 
     # Note: All samples define a `Cloudkms` constant and cause
     #       "already initialized constant" warnings. $VERBOSE is disabled to
@@ -345,23 +345,23 @@ describe "Key Management Service" do
         location_id: @location_id,
         key_ring_id: @key_ring_id,
         crypto_key_id: @crypto_key_id,
-        input_file: @input_file,
-        output_file: temp_output.path
+        plaintext_file: @plaintext_file,
+        ciphertext_file: temp_output.path
       )
-    }.to output(/#{@input_file}/).to_stdout
+    }.to output(/#{@plaintext_file}/).to_stdout
 
     decrypt_test_file(
       project_id: @project_id,
       location_id: @location_id,
       key_ring_id: @key_ring_id,
       crypto_key_id: @crypto_key_id,
-      input_file: temp_output.path,
-      output_file: temp_output.path
+      ciphertext_file: temp_output.path,
+      plaintext_file: temp_output.path
     )
 
-    decrypted_file = File.read temp_output.path
+    plaintext = File.read temp_output.path
 
-    expect(decrypted_file).to match /Some information/
+    expect(plaintext).to match /Some information/
   end
 
   it "can decrypt an encrypted file" do
@@ -372,8 +372,8 @@ describe "Key Management Service" do
       location_id: @location_id,
       key_ring_id: @key_ring_id,
       crypto_key_id: @crypto_key_id,
-      input_file: @input_file,
-      output_file: temp_output.path
+      plaintext_file: @plaintext_file,
+      ciphertext_file: temp_output.path
     )
 
     expect {
@@ -382,14 +382,14 @@ describe "Key Management Service" do
         location_id: @location_id,
         key_ring_id: @key_ring_id,
         crypto_key_id: @crypto_key_id,
-        input_file: temp_output.path,
-        output_file: temp_output.path
+        ciphertext_file: temp_output.path,
+        plaintext_file: temp_output.path
       )
     }.to output(/#{temp_output.path}/).to_stdout
 
-    decrypted_file = File.read temp_output.path
+    plaintext = File.read temp_output.path
 
-    expect(decrypted_file).to match /Some information/
+    expect(plaintext).to match /Some information/
   end
 
   it "can create a crypto key version" do

--- a/kms/spec/quickstart_spec.rb
+++ b/kms/spec/quickstart_spec.rb
@@ -50,8 +50,8 @@ describe "Key Management Service Quickstart" do
     test_parent      = "projects/#{test_project_id}/locations/global"
     test_key_rings   = list_test_key_rings(test_parent).key_rings
 
-    created = test_key_rings.any? do
-      |key_ring| key_ring.name.end_with?(test_key_ring_id)
+    created = test_key_rings.any? do |key_ring|
+      key_ring.name.end_with?(test_key_ring_id)
     end
     if !created
       test_key_ring = create_test_key_ring test_parent, test_key_ring_id

--- a/kms/spec/quickstart_spec.rb
+++ b/kms/spec/quickstart_spec.rb
@@ -50,7 +50,10 @@ describe "Key Management Service Quickstart" do
     test_parent      = "projects/#{test_project_id}/locations/global"
     test_key_rings   = list_test_key_rings(test_parent).key_rings
 
-    if test_key_rings.nil?
+    created = test_key_rings.any? do
+      |key_ring| key_ring.name.end_with?(test_key_ring_id)
+    end
+    if !created
       test_key_ring = create_test_key_ring test_parent, test_key_ring_id
 
       expect(test_key_ring).not_to  eq nil

--- a/kms/spec/quickstart_spec.rb
+++ b/kms/spec/quickstart_spec.rb
@@ -46,7 +46,7 @@ describe "Key Management Service Quickstart" do
 
   it "can list global key rings by name" do
     test_project_id  = ENV["GOOGLE_CLOUD_PROJECT"]
-    test_key_ring_id = "a-keyring-list-#{test_project_id}"
+    test_key_ring_id = "a-key-ring-list-#{test_project_id}"
     test_parent      = "projects/#{test_project_id}/locations/global"
     test_key_rings   = list_test_key_rings(test_parent).key_rings
 


### PR DESCRIPTION
In particular, this change:

- changes to use a consistent "_id" suffix for resource name components
- spells "crypto key" and "key ring" as separate words
- orders location between project and key ring, as in the KMS resource hierarchy
- uses "plaintext" and "ciphertext" consistently to refer to unecrypted and encrypted data, respectively
- fixes some of the text that mixes up resource IDs and resource names

I also updated the quickstart test to work with projects that already have key rings, since it took me a bit to understand why it wasn't passing for me.

Tracking bug: http://b/64758639
