### PR TITLE
[Stackdriver Debugger] Update project_id to project for standalone sample

### DIFF
--- a/stackdriver/ruby_debugger.rb
+++ b/stackdriver/ruby_debugger.rb
@@ -15,8 +15,8 @@
 # [START explicit_debugger_ruby]
 require "google/cloud/debugger"
 
-Google::Cloud::Debugger.new(project_id: "YOUR-PROJECT-ID",
-                            keyfile:    "/path/to/service-account.json").start
+Google::Cloud::Debugger.new(project: "YOUR-PROJECT-ID",
+                            keyfile: "/path/to/service-account.json").start
 # [END explicit_debugger_ruby]
 
 # [START implicit_debugger_ruby]


### PR DESCRIPTION
Update Ruby and Debugger agent sample to define project id using the correct parameter `project` instead of `project_id`.

Reference: https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1797