### PR TITLE
[Rails+Postgres] Updating encoding type to unicode

### DIFF
--- a/appengine/rails-cloudsql-postgres/config/database.yml
+++ b/appengine/rails-cloudsql-postgres/config/database.yml
@@ -37,7 +37,7 @@ test:
 # [START production]
 production:
   adapter: postgresql
-  encoding: postgresql
+  encoding: unicode
   pool: 5
   timeout: 5000
   username: "[YOUR_POSTGRES_USERNAME]"


### PR DESCRIPTION
Fixing database.yml error found in [appengine-gem issue][appengine_issue] where encoding is of type `postgresql` instead of `unicode`.



[appengine_issue]: https://github.com/GoogleCloudPlatform/appengine-ruby/issues/13