### PR TITLE
Keeping costs low

### DIFF
--- a/appengine/hello_world/app.yaml
+++ b/appengine/hello_world/app.yaml
@@ -16,4 +16,16 @@
 runtime: ruby
 env: flex
 entrypoint: bundle exec ruby app.rb
+
+# This sample incurs costs to run on the App Engine flexible environment. 
+# The settings below are to reduce costs during testing and are not appropriate
+# for production use. For more information, see:
+# https://cloud.google.com/appengine/docs/flexible/python/configuring-your-app-with-app-yaml
+manual_scaling:
+  instances: 1
+resources:
+  cpu: 1
+  memory_gb: 0.5
+  disk_size_gb: 10
+
 # [END app_yaml]

--- a/appengine/hello_world/app.yaml
+++ b/appengine/hello_world/app.yaml
@@ -20,7 +20,7 @@ entrypoint: bundle exec ruby app.rb
 # This sample incurs costs to run on the App Engine flexible environment. 
 # The settings below are to reduce costs during testing and are not appropriate
 # for production use. For more information, see:
-# https://cloud.google.com/appengine/docs/flexible/python/configuring-your-app-with-app-yaml
+# https://cloud.google.com/appengine/docs/flexible/ruby/configuring-your-app-with-app-yaml
 manual_scaling:
   instances: 1
 resources:


### PR DESCRIPTION
We've gotten reports of unexpected costs from users that left the hello world running and had two standard instances running for a month. This keeps the costs to a minimum to kick the tires.