### PR TITLE
Change to endpoints managed rollout

### DIFF
--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -47,7 +47,7 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
     # set your project to make commands easier
     GOOGLE_CLOUD_PROJECT=<Your Project ID>
 
-    # Print out your Config ID again, in case you missed it
+    # Print out your Service name again, in case you missed it
     gcloud endpoints services configs list --service hellogrpc.endpoints.${GOOGLE_CLOUD_PROJECT}.cloud.goog
     ```
 

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -77,7 +77,6 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
     ```bash
     GOOGLE_CLOUD_PROJECT=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
     SERVICE_NAME=hellogrpc.endpoints.${GOOGLE_CLOUD_PROJECT}.cloud.goog
-    SERVICE_CONFIG_ID=<Your Config ID>
     ```
 
 1. Pull your credentials to access Container Registry, and run your
@@ -96,7 +95,7 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
         --link=grpc-hello:grpc-hello \
         gcr.io/endpoints-release/endpoints-runtime:1 \
         -s ${SERVICE_NAME} \
-        -v ${SERVICE_CONFIG_ID} \
+        --rollout_strategy managed \
         -P 9000 \
         -a grpc://grpc-hello:50051
     ```
@@ -127,8 +126,7 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
     gcloud container clusters create my-cluster
     ```
 
-1. Edit `deployment.yaml`. Replace `SERVICE_NAME`,
-   `SERVICE_CONFIG_ID`, and `GOOGLE_CLOUD_PROJECT` with your values.
+1. Edit `deployment.yaml`. Replace `SERVICE_NAME` and `GOOGLE_CLOUD_PROJECT` with your values.
 
 1. Deploy to GKE
 

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -41,14 +41,14 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
 1. Deploy your service config to Service Management:
 
     ```bash
-    gcloud service-management deploy out.pb api_config.yaml
+    gcloud endpoints services deploy out.pb api_config.yaml
     # The Config ID should be printed out, looks like: 2017-02-01r0, remember this
 
     # set your project to make commands easier
     GOOGLE_CLOUD_PROJECT=<Your Project ID>
 
     # Print out your Config ID again, in case you missed it
-    gcloud service-management configs list --service hellogrpc.endpoints.${GOOGLE_CLOUD_PROJECT}.cloud.goog
+    gcloud endpoints services configs list --service hellogrpc.endpoints.${GOOGLE_CLOUD_PROJECT}.cloud.goog
     ```
 
 1. Also get an API key from the Console's API Manager for use in the

--- a/endpoints/getting-started-grpc/deployment.yaml
+++ b/endpoints/getting-started-grpc/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           "-P", "9000",
           "-a", "grpc://127.0.0.1:50051",
           "-s", "SERVICE_NAME",
-          "-v", "SERVICE_CONFIG_ID",
+          "--rollout__strategy", "managed",
         ]
         ports:
           - containerPort: 9000

--- a/endpoints/getting-started-grpc/deployment.yaml
+++ b/endpoints/getting-started-grpc/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           "-P", "9000",
           "-a", "grpc://127.0.0.1:50051",
           "-s", "SERVICE_NAME",
-          "--rollout__strategy", "managed",
+          "--rollout_strategy", "managed",
         ]
         ports:
           - containerPort: 9000

--- a/endpoints/getting-started/app.yaml
+++ b/endpoints/getting-started/app.yaml
@@ -7,5 +7,5 @@ endpoints_api_service:
   # The following values are to be replaced by information from the output of
   # 'gcloud endpoints services deploy openapi-appengine.yaml' command.
   name: ENDPOINTS-SERVICE-NAME
-  config_id: ENDPOINTS-CONFIG-ID
+  rollout_strategy: managed
 # [END configuration]

--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           "--http_port", "8081",
           "--backend", "127.0.0.1:8080",
           "--service", "SERVICE_NAME",
-          "--version", "SERVICE_CONFIG_ID",
+          "--rollout_strategy", "managed",
         ]
       # [END esp]
         ports:


### PR DESCRIPTION
We introduce a new feature where we can specify in YAML that service configuration for Endpoints is going to be managed. This means that the service will pull latest deployed service configuration automatically, rather than requiring customer to specify specific version of service configuration.

New flag:
**--rollout_strategy=managed**
Previously the only way to specify a version was using the following flag:
**--version=SERVICE_CONFIG_ID**