### PR TITLE
Remove basePath: "/"

### DIFF
--- a/endpoints/getting-started/openapi-appengine.yaml
+++ b/endpoints/getting-started/openapi-appengine.yaml
@@ -6,7 +6,6 @@ info:
   version: "1.0.0"
 host: "YOUR-PROJECT-ID.appspot.com"
 # [END swagger]
-basePath: "/"
 consumes:
 - "application/json"
 produces:


### PR DESCRIPTION
I'm updating all the openapi files in the getting-started sample in all the sample repos to remove basePath: "/"
Here's the reason from simonz130:

From the OpenAPI 2 spec:
* basePath: "If it is not included, the API is served directly under the host. The value MUST start with a leading slash (/). "
* Paths for methods: "A relative path to an individual endpoint. The field name MUST begin with a slash. The path is appended to the basePath in order to construct the full URL."

This OpenAPI getting-started sample have basePath: "/", which (per strict spec interpretation) means all the paths start with double-slashes. (e.g "//v1/shelves" rather than "/v1/shelves"). Removing basepath="/" fixes that.