### PR TITLE
[Storage] Fix error in KMS tests

### DIFF
--- a/storage/spec/buckets_spec.rb
+++ b/storage/spec/buckets_spec.rb
@@ -124,7 +124,7 @@ describe "Google Cloud Storage buckets sample" do
       /Default KMS key for #{bucket_name} was set to #{@kms_key}/
     }.to_stdout
 
-    expect(@storage.bucket(@bucket_name).default_kms_key).to eq @kms_key
+    expect(@storage.bucket(@bucket_name).default_kms_key).to include @kms_key
 
     @storage.bucket(@bucket_name).default_kms_key = nil
     expect(@storage.bucket(@bucket_name).default_kms_key).to be nil

--- a/storage/spec/files_spec.rb
+++ b/storage/spec/files_spec.rb
@@ -181,7 +181,7 @@ describe "Google Cloud Storage files sample" do
         to eq "Content of test file.txt\n"
   end
 
-  it "can upload a local file to a bucket with encryption key" do
+  it "can upload a local file to a bucket with kms key" do
     delete_file "file.txt"
     expect(@bucket.file "file.txt").to be nil
 
@@ -192,10 +192,11 @@ describe "Google Cloud Storage files sample" do
                           storage_file_path: "file.txt",
                           kms_key:           @kms_key
     }.to output(
-      "Uploaded file.txt and encrypted service side using #{@kms_key}\n"
+      /Uploaded file.txt and encrypted service side using #{@kms_key}/
     ).to_stdout
 
     expect(@bucket.file "file.txt").not_to be nil
+    expect(@bucket.file("file.txt").kms_key).to include @kms_key
     expect(storage_file_content "file.txt").to eq "Content of test file.txt\n"
   end
 


### PR DESCRIPTION
KMS tests should expect to include the used KMS key and not the specific version of the KMS key. 