### PR TITLE
kokoro: only run tests for PRs in modified directories

### DIFF
--- a/spec/kokoro-run-all.sh
+++ b/spec/kokoro-run-all.sh
@@ -30,33 +30,61 @@ function set_failed_status {
 # Print out Ruby version
 ruby --version
 
-# leave this until all tests are added
-for product in \
-  auth \
-  bigquery \
-  bigquerydatatransfer \
-  cdn \
-  datastore \
-  dialogflow \
-  dlp \
-  endpoints/getting-started \
-  firestore \
-  iot \
-  kms \
-  language \
-  pubsub \
-  spanner \
-  speech \
-  translate \
-  video \
-  vision
-do
-  # Run Tests
-  echo "[$product]"
-  pushd "$repo_directory/$product/"
+RUN_ALL_TESTS="0"
+# If this is a nightly test (not a PR), run all tests.
+if [ -z ${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-} ]; then
+  RUN_ALL_TESTS="1"
+fi
 
-  (bundle install && bundle exec rspec --format documentation) || set_failed_status
-  popd
-done
+CHANGED_DIRS=$(git --no-pager diff --name-only HEAD $(git merge-base HEAD master) | grep "/" | cut -d/ -f1 | sort | uniq)
+
+# If test configuration is changed, run all tests.
+if [[ $CHANGED_DIRS =~ "spec" || $CHANGED_DIRS =~ ".kokoro" ]]; then
+  RUN_ALL_TESTS="1"
+fi
+
+if [[ $RUN_ALL_TESTS = "1" ]]; then
+  echo "Running all tests"
+  # leave this until all tests are added
+  for product in \
+    auth \
+    bigquery \
+    bigquerydatatransfer \
+    cdn \
+    datastore \
+    dialogflow \
+    dlp \
+    endpoints/getting-started \
+    firestore \
+    iot \
+    kms \
+    language \
+    pubsub \
+    spanner \
+    speech \
+    translate \
+    video \
+    vision
+  do
+    # Run Tests
+    echo "[$product]"
+    pushd "$repo_directory/$product/"
+
+    (bundle install && bundle exec rspec --format documentation) || set_failed_status
+    popd
+  done
+else
+  SPEC_DIRS=$(find $CHANGED_DIRS -type d -name 'spec' -path "*/*" -not -path "*vendor/*" -exec dirname {} \; | sort | uniq)
+  echo "Running tests in modified directories: $SPEC_DIRS"
+  for product in $SPEC_DIRS
+  do
+    # Run Tests
+    echo "[$product]"
+    pushd "$repo_directory/$product/"
+
+    (bundle install && bundle exec rspec --format documentation) || set_failed_status
+    popd
+  done
+fi
 
 exit $exit_status


### PR DESCRIPTION
All tests are run when it's not a PR or the top level test configs change.

Fixes #294.