### PR TITLE
kokoro: enable remaining tests

### DIFF
--- a/.kokoro/configure_gcloud.sh
+++ b/.kokoro/configure_gcloud.sh
@@ -25,7 +25,7 @@ gcloud -q components update
 
 # Set config.
 gcloud config set disable_prompts True
-gcloud config set project $GOOGLE_CLOUD_PROJECT
+gcloud config set project $E2E_GOOGLE_CLOUD_PROJECT
 gcloud config set app/promote_by_default false
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
 

--- a/appengine/cloudsql-mysql/Gemfile.lock
+++ b/appengine/cloudsql-mysql/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    capybara (3.2.1)
+    capybara (3.4.1)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -15,8 +15,8 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     mustermann (1.0.2)
-    mysql2 (0.5.1)
-    nokogiri (1.8.3)
+    mysql2 (0.5.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     poltergeist (1.18.1)
       capybara (>= 2.1, < 4)
@@ -26,7 +26,7 @@ GEM
     rack (2.0.5)
     rack-protection (2.0.3)
       rack
-    rack-test (1.0.0)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -41,7 +41,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    sequel (5.9.0)
+    sequel (5.10.0)
     sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)

--- a/appengine/cloudsql-mysql/spec/cloudsql_spec.rb
+++ b/appengine/cloudsql-mysql/spec/cloudsql_spec.rb
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative "../app.rb"
 require "rspec"
 require "rack/test"
+require "sequel"
 
 describe "Cloud SQL sample", type: :feature do
   include Rack::Test::Methods
@@ -26,7 +26,11 @@ describe "Cloud SQL sample", type: :feature do
   before do
     @database = Sequel.sqlite database: ":memory:"
 
-    expect(Sequel).to receive(:mysql2).and_return @database
+    expect(Sequel).to receive(:mysql2).at_least(:once).and_return @database
+
+    # Require app.rb after setting up Sequel so Cloud SQL Proxy doesn't need to
+    # be running.
+    require_relative "../app.rb"
   end
 
   it "can create database schema by running create_tables.rb" do

--- a/appengine/cloudsql-mysql/spec/end_to_end_spec.rb
+++ b/appengine/cloudsql-mysql/spec/end_to_end_spec.rb
@@ -17,7 +17,7 @@ require "rspec"
 require "capybara/rspec"
 require "capybara/poltergeist"
 
-Capybara.current_driver = :poltergeist
+Capybara.default_driver = :poltergeist
 
 describe "Cloud SQL on Google App Engine", type: :feature do
   before :all do
@@ -26,10 +26,10 @@ describe "Cloud SQL on Google App Engine", type: :feature do
     app_yaml = File.expand_path("../../app.yaml", __FILE__)
 
     configuration = File.read(app_yaml)
-    configuration.sub! "[YOUR_USER]",        ENV["MYSQL_USER"]
-    configuration.sub! "[YOUR_PASSWORD]",    ENV["MYSQL_PASSWORD"]
-    configuration.sub! "[YOUR_DATABASE]",    ENV["MYSQL_DATABASE"]
-    configuration.sub! "[YOUR_SOCKET_PATH]", ENV["MYSQL_SOCKET_PATH"]
+    configuration.gsub! "[YOUR_USER]",                     ENV["MYSQL_USER"]
+    configuration.gsub! "[YOUR_PASSWORD]",                 ENV["MYSQL_PASSWORD"]
+    configuration.gsub! "[YOUR_DATABASE]",                 ENV["MYSQL_DATABASE"]
+    configuration.gsub! "[YOUR_INSTANCE_CONNECTION_NAME]", ENV["MYSQL_INSTANCE_CONNECTION_NAME"]
 
     File.write(app_yaml, configuration)
 

--- a/appengine/cloudsql-postgres/Gemfile.lock
+++ b/appengine/cloudsql-postgres/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    capybara (3.2.1)
+    capybara (3.4.1)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -15,7 +15,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     mustermann (1.0.2)
-    nokogiri (1.8.3)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     pg (1.0.0)
     poltergeist (1.18.1)
@@ -26,7 +26,7 @@ GEM
     rack (2.0.5)
     rack-protection (2.0.3)
       rack
-    rack-test (1.0.0)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -41,7 +41,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    sequel (5.9.0)
+    sequel (5.10.0)
     sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)

--- a/appengine/cloudsql-postgres/spec/cloudsql_spec.rb
+++ b/appengine/cloudsql-postgres/spec/cloudsql_spec.rb
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative "../app.rb"
 require "rspec"
 require "rack/test"
+require "sequel"
 
 describe "Cloud SQL sample", type: :feature do
   include Rack::Test::Methods
@@ -26,7 +26,11 @@ describe "Cloud SQL sample", type: :feature do
   before do
     @database = Sequel.sqlite database: ":memory:"
 
-    expect(Sequel).to receive(:postgres).and_return @database
+    expect(Sequel).to receive(:postgres).at_least(:once).and_return @database
+
+    # Require app.rb after setting up Sequel so Cloud SQL Proxy doesn't need to
+    # be running.
+    require_relative "../app.rb"
   end
 
   it "can create database schema by running create_tables.rb" do

--- a/appengine/cloudsql-postgres/spec/end_to_end_spec.rb
+++ b/appengine/cloudsql-postgres/spec/end_to_end_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google, Inc
+# Copyright 2018 Google, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,19 +17,19 @@ require "rspec"
 require "capybara/rspec"
 require "capybara/poltergeist"
 
-Capybara.current_driver = :poltergeist
+Capybara.default_driver = :poltergeist
 
-describe "Cloud SQL on Google App Engine", type: :feature do
+describe "Cloud SQL Postgres on Google App Engine", type: :feature do
   before :all do
     skip "End-to-end tests skipped" unless E2E.run?
 
     app_yaml = File.expand_path("../../app.yaml", __FILE__)
 
     configuration = File.read(app_yaml)
-    configuration.sub! "[YOUR_USER]",        ENV["MYSQL_USER"]
-    configuration.sub! "[YOUR_PASSWORD]",    ENV["MYSQL_PASSWORD"]
-    configuration.sub! "[YOUR_DATABASE]",    ENV["MYSQL_DATABASE"]
-    configuration.sub! "[YOUR_SOCKET_PATH]", ENV["MYSQL_SOCKET_PATH"]
+    configuration.gsub! "[YOUR_USER]",                     ENV["POSTGRES_USER"]
+    configuration.gsub! "[YOUR_PASSWORD]",                 ENV["POSTGRES_PASSWORD"]
+    configuration.gsub! "[YOUR_DATABASE]",                 ENV["POSTGRES_DATABASE"]
+    configuration.gsub! "[YOUR_INSTANCE_CONNECTION_NAME]", ENV["POSTGRES_INSTANCE_CONNECTION_NAME"]
 
     File.write(app_yaml, configuration)
 

--- a/appengine/cloudsql/Gemfile.lock
+++ b/appengine/cloudsql/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    capybara (3.2.1)
+    capybara (3.4.1)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -15,8 +15,8 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     mustermann (1.0.2)
-    mysql2 (0.5.1)
-    nokogiri (1.8.3)
+    mysql2 (0.5.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     poltergeist (1.18.1)
       capybara (>= 2.1, < 4)
@@ -26,7 +26,7 @@ GEM
     rack (2.0.5)
     rack-protection (2.0.3)
       rack
-    rack-test (1.0.0)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -41,7 +41,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    sequel (5.9.0)
+    sequel (5.10.0)
     sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)

--- a/appengine/cloudsql/spec/cloudsql_spec.rb
+++ b/appengine/cloudsql/spec/cloudsql_spec.rb
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative "../app.rb"
 require "rspec"
 require "rack/test"
+require "sequel"
 
 describe "Cloud SQL sample", type: :feature do
   include Rack::Test::Methods
@@ -26,7 +26,11 @@ describe "Cloud SQL sample", type: :feature do
   before do
     @database = Sequel.sqlite database: ":memory:"
 
-    expect(Sequel).to receive(:mysql2).and_return @database
+    expect(Sequel).to receive(:mysql2).at_least(:once).and_return @database
+
+    # Require app.rb after setting up Sequel so Cloud SQL Proxy doesn't need to
+    # be running.
+    require_relative "../app.rb"
   end
 
   it "can create database schema by running create_tables.rb" do

--- a/appengine/hello_world/spec/hello_world_spec.rb
+++ b/appengine/hello_world/spec/hello_world_spec.rb
@@ -16,7 +16,7 @@ require_relative "../app.rb"
 require "rspec"
 require "rack/test"
 
-describe "Hello World E2E test" do
+describe "Hello World" do
   include Rack::Test::Methods
 
   def app

--- a/spec/e2e.rb
+++ b/spec/e2e.rb
@@ -52,7 +52,7 @@ class E2E
       key_json = JSON.parse(key_file)
 
       account_name = key_json['client_email'];
-      project_id = ENV["GOOGLE_CLOUD_PROJECT"];
+      project_id = ENV["E2E_GOOGLE_CLOUD_PROJECT"];
 
       # authenticate with gcloud using our credentials file
       self.exec "gcloud config set project #{project_id}"
@@ -72,8 +72,8 @@ class E2E
         return $?.to_i
       end
 
-      # sleeping 1 to ensure URL is callable
-      sleep 1
+      # sleeping 10 to ensure URL is callable
+      sleep 10
 
       # run the specs for the step, but use the remote URL
       @url = "https://#{version}-dot-#{project_id}.appspot.com"


### PR DESCRIPTION
This PR finalizes running all tests in Kokoro. There are 3 E2E tests:
* `appengine/cloudsql-mysql`
* `appengine/cloudsql-postgres`
* `appengine/metadata_server`

These test provide sufficient coverage to make sure AppEngine works without having to deploy >10 AppEngine Flexible applications (would easily take over an hour).

Part of #251. Next step: disable Circle.