### PR TITLE
dialogflow: make tests more robust

### DIFF
--- a/dialogflow/spec/entity_management_spec.rb
+++ b/dialogflow/spec/entity_management_spec.rb
@@ -31,20 +31,13 @@ describe "Entity Management" do
                                  "fake_synonym_for_testing_2"]
 
     hide do
-      # clean up entity type
-      entity_type_ids = get_entity_type_ids project_id: @project_id,
-                                            display_name: @entity_type_display_name
-      entity_type_ids.each do |entity_type_id|
-        puts entity_type_id
-        delete_entity_type project_id: @project_id,
-                           entity_type_id: entity_type_id
-    end
-
-    create_entity_type project_id: @project_id,
-                       display_name: @entity_type_display_name,
-                       kind: @kind
-    @entity_type_id = (get_entity_type_ids project_id: @project_id,
-                                           display_name: @entity_type_display_name).first
+      clean_entity_types project_id: @project_id,
+                         display_name: @entity_type_display_name
+      create_entity_type project_id: @project_id,
+                         display_name: @entity_type_display_name,
+                         kind: @kind
+      @entity_type_id = (get_entity_type_ids project_id: @project_id,
+                                             display_name: @entity_type_display_name).first
     end
   end
 

--- a/dialogflow/spec/entity_type_management_spec.rb
+++ b/dialogflow/spec/entity_type_management_spec.rb
@@ -26,6 +26,20 @@ describe "Entity Type Management" do
     @kind                     = :KIND_MAP
   end
 
+  before :each do
+    hide do
+      clean_entity_types project_id: @project_id,
+                         display_name: @entity_type_display_name
+    end
+  end
+
+  after :each do
+    hide do
+      clean_entity_types project_id: @project_id,
+                         display_name: @entity_type_display_name
+    end
+  end
+
   example "create entity type" do
     expect(
       get_entity_type_ids(project_id: @project_id,
@@ -48,6 +62,9 @@ describe "Entity Type Management" do
 
   example "delete entity type" do
     hide do
+      create_entity_type project_id: @project_id,
+                         display_name: @entity_type_display_name,
+                         kind: @kind
       entity_type_ids = get_entity_type_ids project_id: @project_id,
                                             display_name: @entity_type_display_name
       entity_type_ids.each do |entity_type_id|

--- a/dialogflow/spec/session_entity_type_management_spec.rb
+++ b/dialogflow/spec/session_entity_type_management_spec.rb
@@ -29,30 +29,41 @@ describe "Session Entity Type Management" do
     @entity_values = ["fake_entity_value_1", "fake_entity_value_2"]
   end
 
+  before :each do
+    hide do
+      clean_entity_types project_id: @project_id,
+                         display_name: @entity_type_display_name
+    end
+  end
+
+  after :each do
+    hide do
+      clean_entity_types project_id: @project_id,
+                         display_name: @entity_type_display_name
+    end
+  end
+
+  def create_test_session_entity_type
+    # create an entity type to be overridden
+    create_entity_type project_id: @project_id,
+                       display_name: @entity_type_display_name,
+                       kind: :KIND_MAP
+
+    # create a session
+    detect_intent_texts project_id:    @project_id,
+                        session_id:    @session_id,
+                        texts:         ["hi"],
+                        language_code: "en-US"
+
+    create_session_entity_type project_id: @project_id,
+                               session_id: @session_id,
+                               entity_type_display_name: @entity_type_display_name,
+                               entity_values: @entity_values
+  end
+
   example "create session_entity_type" do
     hide do
-      # clean up entity type
-      entity_type_ids = get_entity_type_ids project_id: @project_id,
-                                            display_name: @entity_type_display_name
-      entity_type_ids.each do |entity_type_id|
-        delete_entity_type project_id: @project_id,
-                           entity_type_id: entity_type_id
-      end
-      # create an entity type to be overridden
-      create_entity_type project_id: @project_id,
-                         display_name: @entity_type_display_name,
-                         kind: :KIND_MAP
-
-      # create a session
-      detect_intent_texts project_id:    @project_id,
-                          session_id:    @session_id,
-                          texts:         ["hi"],
-                          language_code: "en-US"
-
-      create_session_entity_type project_id: @project_id,
-                                 session_id: @session_id,
-                                 entity_type_display_name: @entity_type_display_name,
-                                 entity_values: @entity_values
+      create_test_session_entity_type
     end
     expectation = expect {
       list_session_entity_types project_id: @project_id, session_id: @session_id
@@ -66,6 +77,7 @@ describe "Session Entity Type Management" do
 
   example "delete session_entity_type" do
     hide do
+      create_test_session_entity_type
       delete_session_entity_type project_id: @project_id,
                      session_id: @session_id,
                      entity_type_display_name: @entity_type_display_name
@@ -77,15 +89,5 @@ describe "Session Entity Type Management" do
     expectation.not_to output(/#{@entity_type_display_name}/).to_stdout
     expectation.not_to output(/#{@entity_values[0]}/).to_stdout
     expectation.not_to output(/#{@entity_values[1]}/).to_stdout
-
-    hide do
-      # clean up entity type
-      entity_type_ids = get_entity_type_ids project_id: @project_id,
-                                            display_name: @entity_type_display_name
-      entity_type_ids.each do |entity_type_id|
-        delete_entity_type project_id: @project_id,
-                           entity_type_id: entity_type_id
-      end
-    end
   end
 end

--- a/dialogflow/spec/spec_helper.rb
+++ b/dialogflow/spec/spec_helper.rb
@@ -40,6 +40,15 @@ def get_entity_type_ids project_id:, display_name:
   entity_type_ids
 end
 
+def clean_entity_types project_id:, display_name:
+  entity_type_ids = get_entity_type_ids project_id: project_id,
+                                        display_name: display_name
+  entity_type_ids.each do |entity_type_id|
+    delete_entity_type project_id: project_id,
+                       entity_type_id: entity_type_id
+  end
+end
+
 
 def get_intent_ids project_id:, display_name:
   intents_client = Google::Cloud::Dialogflow::Intents.new


### PR DESCRIPTION
spec/session_entity_type_management_spec.rb fails sometimes if the
delete test is run without the create test (for example, when quota
issues cause the test to fail).

Part of #251.