### PR TITLE
appengine/metadata_server: use Capybara.default_driver

### DIFF
--- a/appengine/metadata_server/spec/metadata_server_spec.rb
+++ b/appengine/metadata_server/spec/metadata_server_spec.rb
@@ -17,7 +17,7 @@ require "rspec"
 require "capybara/rspec"
 require "capybara/poltergeist"
 
-Capybara.current_driver = :poltergeist
+Capybara.default_driver = :poltergeist
 
 describe "Metadata server on Google App Engine", type: :feature do
   before :all do


### PR DESCRIPTION
Seems to be more reliable than current_driver.

Part of #251.