### PR TITLE
Monitoring - metrics examples

### DIFF
--- a/monitoring/Gemfile
+++ b/monitoring/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem "google-cloud-monitoring"
+
+group :test do
+  gem "rspec"
+end

--- a/monitoring/Gemfile.lock
+++ b/monitoring/Gemfile.lock
@@ -1,0 +1,69 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    diff-lcs (1.3)
+    faraday (0.15.3)
+      multipart-post (>= 1.2, < 3)
+    google-cloud-monitoring (0.29.2)
+      google-gax (~> 1.3)
+      googleapis-common-protos-types (>= 1.0.2)
+    google-gax (1.4.0)
+      google-protobuf (~> 3.2)
+      googleapis-common-protos (>= 1.3.5, < 2.0)
+      googleauth (~> 0.6.2)
+      grpc (>= 1.7.2, < 2.0)
+      rly (~> 0.2.3)
+    google-protobuf (3.6.1)
+    googleapis-common-protos (1.3.7)
+      google-protobuf (~> 3.0)
+      googleapis-common-protos-types (~> 1.0)
+      grpc (~> 1.0)
+    googleapis-common-protos-types (1.0.2)
+      google-protobuf (~> 3.0)
+    googleauth (0.6.7)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    grpc (1.15.0)
+      google-protobuf (~> 3.1)
+      googleapis-common-protos-types (~> 1.0.0)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    rly (0.2.3)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-cloud-monitoring
+  rspec
+
+BUNDLED WITH
+   1.16.0

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,13 @@
+<img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
+
+# Google Monitoring Ruby Samples
+
+[monitoring_docs]: https://cloud.google.com/monitoring/docs/ 
+
+## Samples
+
+### Quickstart
+
+```
+$ bundle exec ruby quickstart.rb
+```

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -2,12 +2,42 @@
 
 # Google Monitoring Ruby Samples
 
+The [Google Cloud Stackdriver Monitoring][monitoring_docs] Stackdriver Monitoring provides visibility into the performance, uptime, and overall health of cloud-powered applications. Stackdriver collects metrics, events, and metadata from Google Cloud Platform, Amazon Web Services, hosted uptime probes, application instrumentation, and a variety of common application components including Cassandra, Nginx, Apache Web Server, Elasticsearch, and many others. Stackdriver ingests that data and generates insights via dashboards, charts, and alerts. Stackdriver alerting helps you collaborate by integrating with Slack, PagerDuty, HipChat, Campfire, and more. 
+
 [monitoring_docs]: https://cloud.google.com/monitoring/docs/ 
 
-## Samples
+## Setup
 
-### Quickstart
+### Authentication
 
-```
-$ bundle exec ruby quickstart.rb
-```
+Authentication is typically done through [Application Default Credentials](https://cloud.google.com/docs/authentication#getting_credentials_for_server-centric_flow)
+, which means you do not have to change the code to authenticate as long as your
+environment has credentials. You have a few options for setting up
+authentication:
+
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+
+    `gcloud auth application-default login`
+
+1. When running on App Engine or Compute Engine, credentials are already set-up.
+However, you may need to configure your Compute Engine instance with
+[additional scopes](https://cloud.google.com/compute/docs/authentication#using).
+
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
+. This file can be used to authenticate to Google Cloud Platform services from
+any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable to the path to the key file, for example:
+
+    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+
+### Install Dependencies
+
+1. Install the [Bundler](http://bundler.io/) gem.
+
+1. Install dependencies using:
+
+    `bundle install`
+
+## Run Quickstart
+
+    bundle exec ruby quickstart.rb

--- a/monitoring/metrics.rb
+++ b/monitoring/metrics.rb
@@ -230,7 +230,7 @@ if __FILE__ == $PROGRAM_NAME
     get_metric_descriptor metric_name: ARGV.shift
   else
     puts <<-usage
-Usage: bundle exec ruby snippets.rb [command] [arguments]
+Usage: bundle exec ruby metrics.rb [command] [arguments]
 
 Commands:
   create_metric_descriptor                     <project_id>

--- a/monitoring/metrics.rb
+++ b/monitoring/metrics.rb
@@ -1,13 +1,13 @@
 require "google/cloud/monitoring"
 
 def create_metric_descriptor project_id:
-  # [START monitoring_create_metric]
-  client = Google::Cloud::Monitoring::Metric.new
-  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path project_id
-
   # Random suffix for metric type to avoid collisions with other runs
   random_suffix = rand(36**10).to_s(36)
 
+  # [START monitoring_create_metric]
+  client = Google::Cloud::Monitoring::Metric.new
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path project_id
+  
   descriptor = Google::Api::MetricDescriptor.new(
     type: "custom.googleapis.com/my_metric#{random_suffix}",
     metric_kind: Google::Api::MetricDescriptor::MetricKind::GAUGE,

--- a/monitoring/metrics.rb
+++ b/monitoring/metrics.rb
@@ -1,0 +1,249 @@
+require "google/cloud/monitoring"
+
+# Avoid collisions with other runs
+RANDOM_SUFFIX = Time.now.to_i.to_s
+
+def create_metric_descriptor project_id:
+  # [START monitoring_create_metric]
+  client = Google::Cloud::Monitoring::Metric.new
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+
+  descriptor = Google::Api::MetricDescriptor.new({
+    type: "custom.googleapis.com/my_metric#{RANDOM_SUFFIX}",
+    metric_kind: Google::Api::MetricDescriptor::MetricKind::GAUGE,
+    value_type: Google::Api::MetricDescriptor::ValueType::DOUBLE,
+    description: "This is a simple example of a custom metric.",
+  })
+
+  result = client.create_metric_descriptor(project_name, descriptor)
+  p "Created #{result.name}"
+  p result
+
+  # [END monitoring_create_metric]
+end
+
+def delete_metric_descriptor descriptor_name:
+  # [START monitoring_delete_metric]
+  client = Google::Cloud::Monitoring::Metric.new
+  result = client.delete_metric_descriptor(descriptor_name)
+  p "Deleted metric descriptor #{descriptor_name}."
+  # [END monitoring_delete_metric]
+end
+
+def write_time_series project_id:
+  # [START monitoring_write_timeseries]
+  client = Google::Cloud::Monitoring::Metric.new
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+
+  series = Google::Monitoring::V3::TimeSeries.new
+  metric = Google::Api::Metric.new(type: "custom.googleapis.com/my_metric#{RANDOM_SUFFIX}")
+  series.metric = metric
+
+  resource = Google::Api::MonitoredResource.new(type: "gce_instance")
+  resource.labels["instance_id"] = "1234567890123456789"
+  resource.labels["zone"] = "us-central1-f"
+  series.resource = resource
+
+  point = Google::Monitoring::V3::Point.new
+  point.value = Google::Monitoring::V3::TypedValue.new(double_value: 3.14)
+  now =  Time.now
+  end_time = Google::Protobuf::Timestamp.new(seconds: now.to_i, nanos: now.usec)
+  point.interval = Google::Monitoring::V3::TimeInterval.new(end_time: end_time)
+  series.points << point
+
+  client.create_time_series(project_name, [series])
+  p "Time series created : #{metric.type}"
+  # [END monitoring_write_timeseries]
+end
+
+def list_time_series project_id:
+  # [START monitoring_read_timeseries_simple]
+  client = Google::Cloud::Monitoring::Metric.new
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+
+  interval = Google::Monitoring::V3::TimeInterval.new
+  now = Time.now
+  interval.end_time = Google::Protobuf::Timestamp.new(seconds: now.to_i, nanos: now.usec)
+  interval.start_time = Google::Protobuf::Timestamp.new(seconds: now.to_i - 300, nanos: now.usec)
+
+  results = client.list_time_series(
+    project_name,
+    'metric.type = "compute.googleapis.com/instance/cpu/utilization"',
+    interval,
+    Google::Monitoring::V3::ListTimeSeriesRequest::TimeSeriesView::FULL
+  )
+  results.each do |result|
+    p result
+  end
+  # [END monitoring_read_timeseries_simple]
+end
+
+def list_time_series_header project_id:
+  # [START monitoring_read_timeseries_fields]
+  client = Google::Cloud::Monitoring::Metric.new
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+
+  interval = Google::Monitoring::V3::TimeInterval.new
+  now = Time.now
+  interval.end_time = Google::Protobuf::Timestamp.new(seconds: now.to_i, nanos: now.usec)
+  interval.start_time = Google::Protobuf::Timestamp.new(seconds: now.to_i - 300, nanos: now.usec)
+
+  results = client.list_time_series(
+    project_name,
+    'metric.type = "compute.googleapis.com/instance/cpu/utilization"',
+    interval,
+    Google::Monitoring::V3::ListTimeSeriesRequest::TimeSeriesView::HEADERS
+  )
+  results.each do |result|
+    p result
+  end
+  # [END monitoring_read_timeseries_fields]
+end
+
+def list_time_series_aggregate project_id:
+  # [START monitoring_read_timeseries_align]
+  client = Google::Cloud::Monitoring::Metric.new
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+
+  interval = Google::Monitoring::V3::TimeInterval.new
+  now = Time.now
+  interval.end_time = Google::Protobuf::Timestamp.new(seconds: now.to_i, nanos: now.usec)
+  interval.start_time = Google::Protobuf::Timestamp.new(seconds: now.to_i - 300, nanos: now.usec)
+
+  aggregation = Google::Monitoring::V3::Aggregation.new(
+    alignment_period: { seconds: 300 },
+    per_series_aligner: Google::Monitoring::V3::Aggregation::Aligner::ALIGN_MEAN
+  )
+
+  results = client.list_time_series(
+    project_name,
+    'metric.type = "compute.googleapis.com/instance/cpu/utilization"',
+    interval,
+    Google::Monitoring::V3::ListTimeSeriesRequest::TimeSeriesView::FULL,
+    aggregation: aggregation
+  )
+  results.each do |result|
+    p result
+  end
+
+  # [END monitoring_read_timeseries_align]
+end
+
+def list_time_series_reduce project_id:
+  # [START monitoring_read_timeseries_reduce]
+  client = Google::Cloud::Monitoring::Metric.new
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+
+  interval = Google::Monitoring::V3::TimeInterval.new
+  now = Time.now
+  interval.end_time = Google::Protobuf::Timestamp.new(seconds: now.to_i, nanos: now.usec)
+  interval.start_time = Google::Protobuf::Timestamp.new(seconds: now.to_i - 300, nanos: now.usec)
+
+  aggregation = Google::Monitoring::V3::Aggregation.new(
+    alignment_period: { seconds: 300 },
+    per_series_aligner: Google::Monitoring::V3::Aggregation::Aligner::ALIGN_MEAN,
+    cross_series_reducer: Google::Monitoring::V3::Aggregation::Reducer::REDUCE_MEAN,
+    group_by_fields: ["resource.zone"]
+  )
+
+  results = client.list_time_series(
+    project_name,
+    'metric.type = "compute.googleapis.com/instance/cpu/utilization"',
+    interval,
+    Google::Monitoring::V3::ListTimeSeriesRequest::TimeSeriesView::FULL,
+    aggregation: aggregation
+  )
+  results.each do |result|
+    p result
+  end
+
+  # [END monitoring_read_timeseries_reduce]
+end
+
+def list_metric_descriptors project_id:
+  # [START monitoring_list_descriptors]
+  client = Google::Cloud::Monitoring::Metric.new
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+  results = client.list_metric_descriptors(project_name)
+  results.each do |descriptor|
+    p descriptor.type
+  end
+  # [END monitoring_list_descriptors]
+end
+
+def list_monitored_resources project_id:
+  # [START monitoring_list_resources]
+  client = Google::Cloud::Monitoring::Metric.new
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+  results = client.list_monitored_resource_descriptors(project_name)
+  results.each do |descriptor|
+    p descriptor.type
+  end
+  # [END monitoring_list_resources]
+end
+
+def get_monitored_resource_descriptor project_id:, resource_type:
+  # [START monitoring_get_resource]
+  client = Google::Cloud::Monitoring::Metric.new
+  resource_path = Google::Cloud::Monitoring::V3::MetricServiceClient.monitored_resource_descriptor_path(
+    project_id,
+    resource_type
+  )
+
+ result = client.get_monitored_resource_descriptor(resource_path)
+ p result
+
+ # [END monitoring_get_resource]
+end
+
+def get_metric_descriptor metric_name:
+  # [START monitoring_get_descriptor]
+  client = Google::Cloud::Monitoring::Metric.new
+  descriptor = client.get_metric_descriptor(metric_name)
+  p descriptor
+  # [END monitoring_get_descriptor]
+end
+
+if __FILE__ == $PROGRAM_NAME
+  case ARGV.shift
+  when "create_metric_descriptor"
+    create_metric_descriptor project_id: ARGV.shift
+  when "delete_metric_descriptor"
+    delete_metric_descriptor descriptor_name: ARGV.shift
+  when "write_time_series"
+    write_time_series project_id: ARGV.shift
+  when "list_time_series"
+    list_time_series project_id: ARGV.shift
+  when "list_time_series_header"
+    list_time_series_header project_id: ARGV.shift
+  when "list_time_series_aggregate"
+    list_time_series_aggregate project_id: ARGV.shift
+  when "list_time_series_reduce"
+    list_time_series_reduce project_id: ARGV.shift
+  when "list_metric_descriptors"
+    list_metric_descriptors project_id: ARGV.shift
+  when "list_monitored_resources"
+    list_monitored_resources project_id: ARGV.shift
+  when "get_monitored_resource_descriptor"
+    get_monitored_resource_descriptor project_id: ARGV.shift, resource_type: ARGV.shift
+  when "get_metric_descriptor"
+    get_metric_descriptor metric_name: ARGV.shift
+  else
+    puts <<-usage
+Usage: bundle exec ruby snippets.rb [command] [arguments]
+
+Commands:
+  create_metric_descriptor                     <project_id>
+  delete_metric_descriptor                     <descriptor_name>
+  write_time_series                            <project_id>
+  list_time_series                             <project_id>
+  list_time_series_header                      <project_id>
+  list_time_series_aggregate                   <project_id>
+  list_time_series_reduce                      <project_id>
+  list_metric_descriptors                      <project_id>
+  list_monitored_resources                     <project_id>
+  get_monitored_resource_descriptor            <project_id> <resource_type>
+  get_metric_descriptor                        <metric_name>
+    usage
+  end
+end

--- a/monitoring/metrics.rb
+++ b/monitoring/metrics.rb
@@ -1,31 +1,30 @@
 require "google/cloud/monitoring"
 
-# Avoid collisions with other runs
-RANDOM_SUFFIX = Time.now.to_i.to_s
-
 def create_metric_descriptor project_id:
   # [START monitoring_create_metric]
   client = Google::Cloud::Monitoring::Metric.new
-  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path project_id
 
-  descriptor = Google::Api::MetricDescriptor.new({
-    type: "custom.googleapis.com/my_metric#{RANDOM_SUFFIX}",
+  # Random suffix for metric type to avoid collisions with other runs
+  random_suffix = rand(36**10).to_s(36)
+
+  descriptor = Google::Api::MetricDescriptor.new(
+    type: "custom.googleapis.com/my_metric#{random_suffix}",
     metric_kind: Google::Api::MetricDescriptor::MetricKind::GAUGE,
     value_type: Google::Api::MetricDescriptor::ValueType::DOUBLE,
-    description: "This is a simple example of a custom metric.",
-  })
+    description: "This is a simple example of a custom metric."
+  )
 
-  result = client.create_metric_descriptor(project_name, descriptor)
+  result = client.create_metric_descriptor project_name, descriptor
   p "Created #{result.name}"
   p result
-
   # [END monitoring_create_metric]
 end
 
 def delete_metric_descriptor descriptor_name:
   # [START monitoring_delete_metric]
   client = Google::Cloud::Monitoring::Metric.new
-  result = client.delete_metric_descriptor(descriptor_name)
+  client.delete_metric_descriptor descriptor_name
   p "Deleted metric descriptor #{descriptor_name}."
   # [END monitoring_delete_metric]
 end
@@ -33,25 +32,28 @@ end
 def write_time_series project_id:
   # [START monitoring_write_timeseries]
   client = Google::Cloud::Monitoring::Metric.new
-  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path project_id
+
+  # Random suffix for metric type to avoid collisions with other runs
+  random_suffix = rand(36**10).to_s(36)
 
   series = Google::Monitoring::V3::TimeSeries.new
-  metric = Google::Api::Metric.new(type: "custom.googleapis.com/my_metric#{RANDOM_SUFFIX}")
+  metric = Google::Api::Metric.new type: "custom.googleapis.com/my_metric#{random_suffix}"
   series.metric = metric
 
-  resource = Google::Api::MonitoredResource.new(type: "gce_instance")
+  resource = Google::Api::MonitoredResource.new type: "gce_instance"
   resource.labels["instance_id"] = "1234567890123456789"
   resource.labels["zone"] = "us-central1-f"
   series.resource = resource
 
   point = Google::Monitoring::V3::Point.new
-  point.value = Google::Monitoring::V3::TypedValue.new(double_value: 3.14)
-  now =  Time.now
-  end_time = Google::Protobuf::Timestamp.new(seconds: now.to_i, nanos: now.usec)
-  point.interval = Google::Monitoring::V3::TimeInterval.new(end_time: end_time)
+  point.value = Google::Monitoring::V3::TypedValue.new double_value: 3.14
+  now = Time.now
+  end_time = Google::Protobuf::Timestamp.new seconds: now.to_i, nanos: now.usec
+  point.interval = Google::Monitoring::V3::TimeInterval.new end_time: end_time
   series.points << point
 
-  client.create_time_series(project_name, [series])
+  client.create_time_series project_name, [series]
   p "Time series created : #{metric.type}"
   # [END monitoring_write_timeseries]
 end
@@ -59,12 +61,12 @@ end
 def list_time_series project_id:
   # [START monitoring_read_timeseries_simple]
   client = Google::Cloud::Monitoring::Metric.new
-  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path project_id
 
   interval = Google::Monitoring::V3::TimeInterval.new
   now = Time.now
-  interval.end_time = Google::Protobuf::Timestamp.new(seconds: now.to_i, nanos: now.usec)
-  interval.start_time = Google::Protobuf::Timestamp.new(seconds: now.to_i - 300, nanos: now.usec)
+  interval.end_time = Google::Protobuf::Timestamp.new seconds: now.to_i, nanos: now.usec
+  interval.start_time = Google::Protobuf::Timestamp.new seconds: now.to_i - 300, nanos: now.usec
 
   results = client.list_time_series(
     project_name,
@@ -81,12 +83,12 @@ end
 def list_time_series_header project_id:
   # [START monitoring_read_timeseries_fields]
   client = Google::Cloud::Monitoring::Metric.new
-  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path project_id
 
   interval = Google::Monitoring::V3::TimeInterval.new
   now = Time.now
-  interval.end_time = Google::Protobuf::Timestamp.new(seconds: now.to_i, nanos: now.usec)
-  interval.start_time = Google::Protobuf::Timestamp.new(seconds: now.to_i - 300, nanos: now.usec)
+  interval.end_time = Google::Protobuf::Timestamp.new seconds: now.to_i, nanos: now.usec
+  interval.start_time = Google::Protobuf::Timestamp.new seconds: now.to_i - 300, nanos: now.usec
 
   results = client.list_time_series(
     project_name,
@@ -103,12 +105,12 @@ end
 def list_time_series_aggregate project_id:
   # [START monitoring_read_timeseries_align]
   client = Google::Cloud::Monitoring::Metric.new
-  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path project_id
 
   interval = Google::Monitoring::V3::TimeInterval.new
   now = Time.now
-  interval.end_time = Google::Protobuf::Timestamp.new(seconds: now.to_i, nanos: now.usec)
-  interval.start_time = Google::Protobuf::Timestamp.new(seconds: now.to_i - 300, nanos: now.usec)
+  interval.end_time = Google::Protobuf::Timestamp.new seconds: now.to_i, nanos: now.usec
+  interval.start_time = Google::Protobuf::Timestamp.new seconds: now.to_i - 300, nanos: now.usec
 
   aggregation = Google::Monitoring::V3::Aggregation.new(
     alignment_period: { seconds: 300 },
@@ -132,12 +134,12 @@ end
 def list_time_series_reduce project_id:
   # [START monitoring_read_timeseries_reduce]
   client = Google::Cloud::Monitoring::Metric.new
-  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path project_id
 
   interval = Google::Monitoring::V3::TimeInterval.new
   now = Time.now
-  interval.end_time = Google::Protobuf::Timestamp.new(seconds: now.to_i, nanos: now.usec)
-  interval.start_time = Google::Protobuf::Timestamp.new(seconds: now.to_i - 300, nanos: now.usec)
+  interval.end_time = Google::Protobuf::Timestamp.new seconds: now.to_i, nanos: now.usec
+  interval.start_time = Google::Protobuf::Timestamp.new seconds: now.to_i - 300, nanos: now.usec
 
   aggregation = Google::Monitoring::V3::Aggregation.new(
     alignment_period: { seconds: 300 },
@@ -163,8 +165,8 @@ end
 def list_metric_descriptors project_id:
   # [START monitoring_list_descriptors]
   client = Google::Cloud::Monitoring::Metric.new
-  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
-  results = client.list_metric_descriptors(project_name)
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path project_id
+  results = client.list_metric_descriptors project_name
   results.each do |descriptor|
     p descriptor.type
   end
@@ -174,8 +176,8 @@ end
 def list_monitored_resources project_id:
   # [START monitoring_list_resources]
   client = Google::Cloud::Monitoring::Metric.new
-  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
-  results = client.list_monitored_resource_descriptors(project_name)
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path project_id
+  results = client.list_monitored_resource_descriptors project_name
   results.each do |descriptor|
     p descriptor.type
   end
@@ -190,16 +192,15 @@ def get_monitored_resource_descriptor project_id:, resource_type:
     resource_type
   )
 
- result = client.get_monitored_resource_descriptor(resource_path)
- p result
-
- # [END monitoring_get_resource]
+  result = client.get_monitored_resource_descriptor resource_path
+  p result
+  # [END monitoring_get_resource]
 end
 
 def get_metric_descriptor metric_name:
   # [START monitoring_get_descriptor]
   client = Google::Cloud::Monitoring::Metric.new
-  descriptor = client.get_metric_descriptor(metric_name)
+  descriptor = client.get_metric_descriptor metric_name
   p descriptor
   # [END monitoring_get_descriptor]
 end
@@ -229,21 +230,21 @@ if __FILE__ == $PROGRAM_NAME
   when "get_metric_descriptor"
     get_metric_descriptor metric_name: ARGV.shift
   else
-    puts <<-usage
-Usage: bundle exec ruby metrics.rb [command] [arguments]
+    puts <<~USAGE
+      Usage: bundle exec ruby metrics.rb [command] [arguments]
 
-Commands:
-  create_metric_descriptor                     <project_id>
-  delete_metric_descriptor                     <descriptor_name>
-  write_time_series                            <project_id>
-  list_time_series                             <project_id>
-  list_time_series_header                      <project_id>
-  list_time_series_aggregate                   <project_id>
-  list_time_series_reduce                      <project_id>
-  list_metric_descriptors                      <project_id>
-  list_monitored_resources                     <project_id>
-  get_monitored_resource_descriptor            <project_id> <resource_type>
-  get_metric_descriptor                        <metric_name>
-    usage
+      Commands:
+        create_metric_descriptor                     <project_id>
+        delete_metric_descriptor                     <descriptor_name>
+        write_time_series                            <project_id>
+        list_time_series                             <project_id>
+        list_time_series_header                      <project_id>
+        list_time_series_aggregate                   <project_id>
+        list_time_series_reduce                      <project_id>
+        list_metric_descriptors                      <project_id>
+        list_monitored_resources                     <project_id>
+        get_monitored_resource_descriptor            <project_id> <resource_type>
+        get_metric_descriptor                        <metric_name>
+    USAGE
   end
 end

--- a/monitoring/quickstart.rb
+++ b/monitoring/quickstart.rb
@@ -2,37 +2,31 @@ require "google/cloud/monitoring"
 
 def quickstart
   # [START monitoring_quickstart]
-
-  # TODO: Replace Google Cloud Platform project ID
+  # Your Google Cloud Platform project ID
   project_id = "YOUR_PROJECT_ID"
 
   # Instantiates a client
   metric_service_client = Google::Cloud::Monitoring::Metric.new
-  # Using keyfile.json
-  # metric_service_client = Google::Cloud::Monitoring::Metric.new(credentials: 'keyfile.json')
-  project_path = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+  project_path = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path project_id
 
   series = Google::Monitoring::V3::TimeSeries.new
+  series.metric = Google::Api::Metric.new type: "custom.googleapis.com/my_metric"
 
-  metric = Google::Api::Metric.new(type: "custom.googleapis.com/my_metric")
-  series.metric = metric
-
-  resource = Google::Api::MonitoredResource.new(type: "gce_instance")
+  resource = Google::Api::MonitoredResource.new type: "gce_instance"
   resource.labels["instance_id"] = "1234567890123456789"
   resource.labels["zone"] = "us-central1-f"
   series.resource = resource
 
   point = Google::Monitoring::V3::Point.new
   point.value = Google::Monitoring::V3::TypedValue.new(double_value: 3.14)
-  now =  Time.now
-  end_time = Google::Protobuf::Timestamp.new(seconds: now.to_i, nanos: now.usec)
-  point.interval = Google::Monitoring::V3::TimeInterval.new(end_time: end_time)
+  now = Time.now
+  end_time = Google::Protobuf::Timestamp.new seconds: now.to_i, nanos: now.usec
+  point.interval = Google::Monitoring::V3::TimeInterval.new end_time: end_time
   series.points << point
 
-  metric_service_client.create_time_series(project_path, [series])
+  metric_service_client.create_time_series project_path, [series]
 
-  p "Successfully wrote time series."
-
+  puts "Successfully wrote time series."
   # [END monitoring_quickstart]
 end
 

--- a/monitoring/quickstart.rb
+++ b/monitoring/quickstart.rb
@@ -1,0 +1,40 @@
+require "google/cloud/monitoring"
+
+def quickstart
+  # [START monitoring_quickstart]
+
+  # TODO: Replace Google Cloud Platform project ID
+  project_id = "YOUR_PROJECT_ID"
+
+  # Instantiates a client
+  metric_service_client = Google::Cloud::Monitoring::Metric.new
+  # Using keyfile.json
+  # metric_service_client = Google::Cloud::Monitoring::Metric.new(credentials: 'keyfile.json')
+  project_path = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path(project_id)
+
+  series = Google::Monitoring::V3::TimeSeries.new
+
+  metric = Google::Api::Metric.new(type: "custom.googleapis.com/my_metric")
+  series.metric = metric
+
+  resource = Google::Api::MonitoredResource.new(type: "gce_instance")
+  resource.labels["instance_id"] = "1234567890123456789"
+  resource.labels["zone"] = "us-central1-f"
+  series.resource = resource
+
+  point = Google::Monitoring::V3::Point.new
+  point.value = Google::Monitoring::V3::TypedValue.new(double_value: 3.14)
+  now =  Time.now
+  end_time = Google::Protobuf::Timestamp.new(seconds: now.to_i, nanos: now.usec)
+  point.interval = Google::Monitoring::V3::TimeInterval.new(end_time: end_time)
+  series.points << point
+
+  metric_service_client.create_time_series(project_path, [series])
+
+  p "Successfully wrote time series."
+
+  # [END monitoring_quickstart]
+end
+
+# Run
+quickstart


### PR DESCRIPTION

Issue: https://github.com/GoogleCloudPlatform/ruby-docs-samples/issues/359

 - monitoring_quickstart
-  monitoring_create_metric
-  monitoring_delete_metric
-  monitoring_write_timeseries
-  monitoring_read_timeseries_simple
-  monitoring_read_timeseries_fields
-  monitoring_read_timeseries_align
-  monitoring_read_timeseries_reduce
-  monitoring_list_descriptors
-  monitoring_get_descriptor
-   monitoring_list_resources
-   monitoring_get_resource