### PR TITLE
Extend snippet tags for cursor example

### DIFF
--- a/datastore/sample.rb
+++ b/datastore/sample.rb
@@ -475,6 +475,7 @@ end
 def cursor_paging
   datastore = Google::Cloud::Datastore.new
 
+  # [START datastore_cursor_paging]
   page_size = 2
   query = datastore.query("Task").
           limit(page_size)
@@ -482,7 +483,6 @@ def cursor_paging
 
   page_cursor = tasks.cursor
 
-  # [START datastore_cursor_paging]
   query = datastore.query("Task").
           limit(page_size).
           start(page_cursor)


### PR DESCRIPTION
Extend page_cursor example in the docs. Received docs feedback that it was hard to understand where some of the values in the snippet came from:

https://cloud.google.com/datastore/docs/concepts/queries#datastore-datastore-cursor-paging-ruby