### PR TITLE
Fix typo (array placeholder missing opening bracket)

### DIFF
--- a/dialogflow/detect_intent_texts.rb
+++ b/dialogflow/detect_intent_texts.rb
@@ -19,7 +19,7 @@ def detect_intent_texts project_id:, session_id:, texts:, language_code:
   # [START dialogflow_detect_intent_text]
   # project_id = "Your Google Cloud project ID"
   # session_id = "mysession"
-  # texts = "hello", "book a meeting room"]
+  # texts = ["hello", "book a meeting room"]
   # language_code = "en-US"
 
   require "google/cloud/dialogflow"


### PR DESCRIPTION
```diff
-  # texts = "hello", "book a meeting room"]
+  # texts = ["hello", "book a meeting room"]
```