### PR TITLE
Fix missing subscriptions.rb in README.md

### DIFF
--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -107,7 +107,7 @@ Usage:
 
 Example:
 
-    bundle exec ruby list_subscriptions YOUR-PROJECT-ID
+    bundle exec ruby subscriptions.rb list_subscriptions YOUR-PROJECT-ID
 
     Subscriptions:
     YOUR-SUBSCRIPTION


### PR DESCRIPTION
Like a #398 

```diff
-    bundle exec ruby list_subscriptions YOUR-PROJECT-ID	
+    bundle exec ruby subscriptions.rb list_subscriptions YOUR-PROJECT-ID
```