### PR TITLE
Fix publish message for some listen_* methods.

### DIFF
--- a/pubsub/topics.rb
+++ b/pubsub/topics.rb
@@ -170,7 +170,7 @@ def publish_message project_id:, topic_name:
   pubsub = Google::Cloud::Pubsub.new project: project_id
 
   topic = pubsub.topic topic_name
-  topic.publish data: "This is a test message."
+  topic.publish "This is a test message."
 
   puts "Message published."
   # [END pubsub_quickstart_publisher]


### PR DESCRIPTION
`publish_message` method publishes `data: "This is a test message."` despite other methods publish String.
Consequently, couldn't show `This is a test message.` in some `listen_*` methods.


### Before

```
$ bundle exec ruby subscriptions.rb listen_for_messages YOUR-PROJECT-ID new_subscription
Received message:
```

### After

```
$ bundle exec ruby subscriptions.rb listen_for_messages YOUR-PROJECT-ID new_subscription
Received message: This is a test message.
```