### PR TITLE
storage: add bucket policy only samples

### DIFF
--- a/storage/Gemfile.lock
+++ b/storage/Gemfile.lock
@@ -79,4 +79,4 @@ DEPENDENCIES
   rspec-retry
 
 BUNDLED WITH
-   2.0.1
+   1.17.0

--- a/storage/Gemfile.lock
+++ b/storage/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
@@ -9,7 +9,7 @@ GEM
     digest-crc (0.4.1)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    google-api-client (0.27.3)
+    google-api-client (0.28.4)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.10.0)
       httpclient (>= 2.8.1, < 3.0)
@@ -17,16 +17,16 @@ GEM
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
       signet (~> 0.10)
-    google-cloud-core (1.2.7)
+    google-cloud-core (1.3.0)
       google-cloud-env (~> 1.0)
     google-cloud-env (1.0.5)
       faraday (~> 0.11)
-    google-cloud-storage (1.15.0)
+    google-cloud-storage (1.17.0)
       digest-crc (~> 0.4)
-      google-api-client (~> 0.23)
+      google-api-client (~> 0.26)
       google-cloud-core (~> 1.2)
-      googleauth (~> 0.6.2)
-    googleauth (0.6.7)
+      googleauth (>= 0.6.2, < 0.10.0)
+    googleauth (0.8.0)
       faraday (~> 0.12)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -79,4 +79,4 @@ DEPENDENCIES
   rspec-retry
 
 BUNDLED WITH
-   1.16.2
+   2.0.1

--- a/storage/README.md
+++ b/storage/README.md
@@ -47,6 +47,9 @@ Commands:
   enable_default_event_based_hold  <bucket>                  Enable event-based hold for a bucket
   disable_default_event_based_hold <bucket>                  Disable event-based hold for a bucket
   get_default_event_based_hold     <bucket>                  Get state of event-based hold for a bucket
+  enable_bucket_policy_only        <bucket>                  Enable Bucket Policy Only for a bucket
+  disable_bucket_policy_only       <bucket>                  Disable Bucket Policy Only for a bucket
+  get_bucket_policy_only           <bucket>                  Get Bucket Policy Only for a bucket
 
 Environment variables:
   GOOGLE_CLOUD_PROJECT must be set to your Google Cloud project ID

--- a/storage/buckets.rb
+++ b/storage/buckets.rb
@@ -88,7 +88,7 @@ def disable_bucket_policy_only project_id:, bucket_name:
 
   bucket.policy_only = false
 
-  puts "Bucket Policy Only was disabled for #{bucket_name}"
+  puts "Bucket Policy Only was disabled for #{bucket_name}."
   # [END storage_disable_bucket_policy_only]
 end
 
@@ -104,7 +104,7 @@ def enable_bucket_policy_only project_id:, bucket_name:
 
   bucket.policy_only = true
 
-  puts "Bucket Policy Only was enabled for #{bucket_name}"
+  puts "Bucket Policy Only was enabled for #{bucket_name}."
   # [END storage_enable_bucket_policy_only]
 end
 
@@ -122,7 +122,7 @@ def get_bucket_policy_only project_id:, bucket_name:
     puts "Bucket Policy Only is enabled for #{bucket_name}."
     puts "Bucket will be locked on #{bucket.policy_only_locked_at}."
   else
-    puts "Bucket Policy Only is enabled for #{bucket_name}."
+    puts "Bucket Policy Only is disabled for #{bucket_name}."
   end
   # [END storage_get_bucket_policy_only]
 end

--- a/storage/buckets.rb
+++ b/storage/buckets.rb
@@ -76,6 +76,57 @@ def get_requester_pays_status project_id:, bucket_name:
   # [END get_requester_pays_status]
 end
 
+def disable_bucket_policy_only project_id:, bucket_name:
+  # [START storage_disable_bucket_policy_only]
+  # project_id  = "Your Google Cloud project ID"
+  # bucket_name = "Name of your Google Cloud Storage bucket"
+
+  require "google/cloud/storage"
+
+  storage = Google::Cloud::Storage.new project_id: project_id
+  bucket  = storage.bucket bucket_name
+
+  bucket.policy_only = false
+
+  puts "Bucket Policy Only was disabled for #{bucket_name}"
+  # [END storage_disable_bucket_policy_only]
+end
+
+def enable_bucket_policy_only project_id:, bucket_name:
+  # [START storage_enable_bucket_policy_only]
+  # project_id  = "Your Google Cloud project ID"
+  # bucket_name = "Name of your Google Cloud Storage bucket"
+
+  require "google/cloud/storage"
+
+  storage = Google::Cloud::Storage.new project_id: project_id
+  bucket  = storage.bucket bucket_name
+
+  bucket.policy_only = true
+
+  puts "Bucket Policy Only was enabled for #{bucket_name}"
+  # [END storage_enable_bucket_policy_only]
+end
+
+def get_bucket_policy_only project_id:, bucket_name:
+  # [START storage_get_bucket_policy_only]
+  # project_id  = "Your Google Cloud project ID"
+  # bucket_name = "Name of your Google Cloud Storage bucket"
+
+  require "google/cloud/storage"
+
+  storage = Google::Cloud::Storage.new project_id: project_id
+  bucket  = storage.bucket bucket_name
+
+  if bucket.policy_only?
+    puts "Bucket Policy Only is enabled for #{bucket_name}."
+    puts "Bucket will be locked on #{bucket.policy_only_locked_at}."
+  else
+    puts "Bucket Policy Only is enabled for #{bucket_name}."
+  end
+  # [END storage_get_bucket_policy_only]
+end
+
 def enable_default_kms_key project_id:, bucket_name:, default_kms_key:
   # [START storage_set_bucket_default_kms_key]
   # project_id      = "Your Google Cloud project ID"
@@ -388,6 +439,15 @@ if __FILE__ == $0
   when "get_default_event_based_hold"
     get_default_event_based_hold project_id: project_id,
                                  bucket_name: ARGV.shift
+  when "enable_bucket_policy_only"
+    enable_bucket_policy_only project_id: project_id,
+                              bucket_name: ARGV.shift
+  when "disable_bucket_policy_only"
+    disable_bucket_policy_only project_id: project_id,
+                               bucket_name: ARGV.shift
+  when "get_bucket_policy_only"
+    get_bucket_policy_only project_id: project_id,
+                           bucket_name: ARGV.shift
   else
     puts <<-usage
 Usage: bundle exec ruby buckets.rb [command] [arguments]
@@ -411,6 +471,9 @@ Commands:
   enable_default_event_based_hold  <bucket>                  Enable event-based hold for a bucket
   disable_default_event_based_hold <bucket>                  Disable event-based hold for a bucket
   get_default_event_based_hold     <bucket>                  Get state of event-based hold for a bucket
+  enable_bucket_policy_only        <bucket>                  Enable Bucket Policy Only for a bucket
+  disable_bucket_policy_only       <bucket>                  Disable Bucket Policy Only for a bucket
+  get_bucket_policy_only           <bucket>                  Get Bucket Policy Only for a bucket
 
 Environment variables:
   GOOGLE_CLOUD_PROJECT must be set to your Google Cloud project ID

--- a/storage/spec/buckets_spec.rb
+++ b/storage/spec/buckets_spec.rb
@@ -113,6 +113,51 @@ describe "Google Cloud Storage buckets sample" do
     }.to_stdout
   end
 
+  example "disable bucket policy only" do
+    @storage.bucket(@bucket_name).policy_only = true
+
+    expect(@storage.bucket(@bucket_name).policy_only?).to be true
+
+    expect {
+      disable_bucket_policy_only project_id:  @project_id,
+                                 bucket_name: @bucket_name
+    }.to output{
+      /Bucket Policy Only was disabled for #{@bucket_name}/
+    }.to_stdout
+
+    expect(@storage.bucket(@bucket_name).policy_only?).to be false
+  end
+
+  example "enable bucket policy only" do
+    @storage.bucket(@bucket_name).policy_only = false
+
+    expect(@storage.bucket(@bucket_name).policy_only?).to be false
+
+    expect {
+      enable_bucket_policy_only project_id:  @project_id,
+                                bucket_name: @bucket_name
+    }.to output{
+      /Bucket Policy Only was enabled for #{@bucket_name}/
+    }.to_stdout
+
+    expect(@storage.bucket(@bucket_name).policy_only?).to be true
+    @storage.bucket(@bucket_name).policy_only = false
+  end
+
+  example "get bucket policy only" do
+    @storage.bucket(@bucket_name).policy_only = true
+    expect(@storage.bucket(@bucket_name).policy_only?).to be true
+
+    expect {
+      get_bucket_policy_only project_id:  @project_id,
+                             bucket_name: @bucket_name
+    }.to output{
+      /Bucket Policy Only is enabled for #{@bucket_name}/
+    }.to_stdout
+
+    @storage.bucket(@bucket_name).policy_only = false
+  end
+
   example "enable default kms key" do
     @storage.bucket(@bucket_name).default_kms_key = nil
 


### PR DESCRIPTION
Samples for bucket policy only:
https://cloud.google.com/storage/docs/using-bucket-policy-only