### PR TITLE
BigQuery Snippets: Use autodetected location

### DIFF
--- a/bigquery/snippets/load_from_file.rb
+++ b/bigquery/snippets/load_from_file.rb
@@ -24,8 +24,6 @@ def load_from_file(dataset_id = "your_dataset_id",
   load_job = dataset.load_job table_id, file_path do |config|
     config.skip_leading = 1
     config.autodetect   = true
-    # Must match the destination dataset location.
-    config.location     = "US"
   end
   load_job.wait_until_done! # Waits for table load to complete.
 

--- a/bigquery/snippets/load_from_file.rb
+++ b/bigquery/snippets/load_from_file.rb
@@ -21,6 +21,7 @@ def load_from_file(dataset_id = "your_dataset_id",
   dataset  = bigquery.dataset dataset_id
   table_id = "new_table_id"
 
+  # Infer the config.location based on the location of the referenced dataset.
   load_job = dataset.load_job table_id, file_path do |config|
     config.skip_leading = 1
     config.autodetect   = true


### PR DESCRIPTION
Use autodetected location.

> In the example provided, it is written that The location must be specified, but the example works even without setting location for datasets located in US and asia-northeast1. Whether specifying location for an upload job is an absolute requirement or not is affecting an application I'm working on. Can you provide details?

See [b/116968956](http://b/116968956)