### PR TITLE
add nodejs to docker images

### DIFF
--- a/.kokoro/docker/ruby-2.4/Dockerfile
+++ b/.kokoro/docker/ruby-2.4/Dockerfile
@@ -2,6 +2,7 @@ FROM ruby:2.4-stretch
 
 ENTRYPOINT /bin/bash
 
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y \
     build-essential \
@@ -12,7 +13,8 @@ RUN apt-get install -y \
     libfreetype6 \
     libfontconfig1-dev \
     libfontconfig1 \
-    memcached
+    memcached \
+    nodejs
 RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
 RUN tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/share/
 RUN ln -s /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/

--- a/.kokoro/docker/ruby-2.5/Dockerfile
+++ b/.kokoro/docker/ruby-2.5/Dockerfile
@@ -2,6 +2,7 @@ FROM ruby:2.5-stretch
 
 ENTRYPOINT /bin/bash
 
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y \
     build-essential \
@@ -12,7 +13,8 @@ RUN apt-get install -y \
     libfreetype6 \
     libfontconfig1-dev \
     libfontconfig1 \
-    memcached
+    memcached \
+    nodejs
 RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
 RUN tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/share/
 RUN ln -s /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/

--- a/.kokoro/docker/ruby-2.6/Dockerfile
+++ b/.kokoro/docker/ruby-2.6/Dockerfile
@@ -2,6 +2,7 @@ FROM ruby:2.6-stretch
 
 ENTRYPOINT /bin/bash
 
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y \
     build-essential \
@@ -12,7 +13,8 @@ RUN apt-get install -y \
     libfreetype6 \
     libfontconfig1-dev \
     libfontconfig1 \
-    memcached
+    memcached \
+    nodejs
 RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
 RUN tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/share/
 RUN ln -s /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/


### PR DESCRIPTION
Enables controller tests in https://github.com/GoogleCloudPlatform/ruby-docs-samples/pull/449 and would eventually allow for https://github.com/JustinBeckwith/linkinator to be added.