### PR TITLE
remove "-" from e2e versions set by #versionize

### DIFF
--- a/spec/e2e.rb
+++ b/spec/e2e.rb
@@ -106,7 +106,7 @@ class E2E
     end
 
     def versionize name
-      version_name = name.tr "^A-Za-z0-9", "-"
+      version_name = name.tr "^A-Za-z0-9", ""
       name_length  = 11
 
       version_name[-name_length, name_length] || version_name


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/ruby-docs-samples/issues/416