### PR TITLE
Add CLI support to translate_v3_translate_text

### DIFF
--- a/translate/spec/translate_v3_samples_spec.rb
+++ b/translate/spec/translate_v3_samples_spec.rb
@@ -63,17 +63,8 @@ describe "Google Translate API samples (V3)" do
   end
 
   example "Translating Text", :translate_v3_translate_text do
-    text = "Hello, world!"
-    target_language = "fr"
-    parent = translate.class.location_path project_id, "global"
-
-    response = translate.translate_text [text], target_language, parent
-
-    allow(Google::Cloud::Translate).to receive(:new).and_return(client_double)
-    allow(client_double).to receive(:translate_text).and_return(response)
-
     expect do
-      translate_v3_translate_text
+      translate_v3_translate_text project_id: project_id, text: "Hello, world!", target_language: "fr"
     end.to output("Translated text: Bonjour le monde!\n").to_stdout
   end
 

--- a/translate/translate_v3_translate_text.rb
+++ b/translate/translate_v3_translate_text.rb
@@ -12,19 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def translate_v3_translate_text
+def translate_v3_translate_text project_id:, text: "Hello, world!", target_language: "fr"
+  # Store the method arguments to be set later on.
+  sample_original_args = { project_id: project_id, text: text, target_language: target_language }
+
   # [START translate_v3_translate_text]
   require "google/cloud/translate"
 
   client = Google::Cloud::Translate.new
 
-  project = "[Google Cloud Project ID]"
+  project_id = "[Google Cloud Project ID]"
 
   # The content to translate in string format
-  contents = ["Hello, world!"]
+  text = "Hello, world!"
   # Required. The BCP-47 language code to use for translation.
   target_language = "fr"
-  parent = client.class.location_path project, "global"
+  # [END translate_v3_translate_text]
+  # Set the real values for these variables from the method arguments.
+  project_id      = sample_original_args[:project_id]
+  text            = sample_original_args[:text]
+  target_language = sample_original_args[:target_language]
+  # [START translate_v3_translate_text]
+  parent = client.class.location_path project_id, "global"
+  contents = [text]
 
   response = client.translate_text contents, target_language, parent
 
@@ -33,4 +43,19 @@ def translate_v3_translate_text
     puts "Translated text: #{translation.translated_text}"
   end
   # [END translate_v3_translate_text]
+end
+
+if $PROGRAM_NAME == __FILE__
+  # Code below processes command-line arguments to execute this code sample.
+  args = {}
+
+  require "optparse"
+  ARGV.options do |opts|
+    opts.on("--project_id=val")      { |val| args[:project_id] = val }
+    opts.on("--text_content=val")    { |val| args[:text] = val }
+    opts.on("--target_language=val") { |val| args[:target_language] = val }
+    opts.parse!
+  end
+
+  translate_v3_translate_text args
 end


### PR DESCRIPTION
This PR tweaks the existing translate samples in a couple ways. First, it removes the mocks from the specs. Second, it adds code to each sample to allow it to be called directly. Third, it fixes a complaint I have about the other samples that are being generated, namely that the variables that are being set by the test or by calling the file directly are commented out in the sample code. IMO the sample should not direct users to uncomment and change the values in the code to run, but to change the values only. This PR implements this by stopping and starting the sample tags to set the actual values to be used.