### PR TITLE
Fix monitoring delete_metric_descriptor example

### DIFF
--- a/monitoring/metrics.rb
+++ b/monitoring/metrics.rb
@@ -21,10 +21,12 @@ def create_metric_descriptor project_id:
   # [END monitoring_create_metric]
 end
 
-def delete_metric_descriptor descriptor_name:
+def delete_metric_descriptor project_id:, descriptor_name:
   # [START monitoring_delete_metric]
   client = Google::Cloud::Monitoring::Metric.new
-  client.delete_metric_descriptor descriptor_name
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.metric_descriptor_path(project_id, descriptor_name)
+
+  client.delete_metric_descriptor project_name
   p "Deleted metric descriptor #{descriptor_name}."
   # [END monitoring_delete_metric]
 end
@@ -210,7 +212,7 @@ if $PROGRAM_NAME == __FILE__
   when "create_metric_descriptor"
     create_metric_descriptor project_id: ARGV.shift
   when "delete_metric_descriptor"
-    delete_metric_descriptor descriptor_name: ARGV.shift
+    delete_metric_descriptor project_id: ARGV.shift, descriptor_name: ARGV.shift
   when "write_time_series"
     write_time_series project_id: ARGV.shift
   when "list_time_series"
@@ -235,7 +237,7 @@ if $PROGRAM_NAME == __FILE__
 
       Commands:
         create_metric_descriptor                     <project_id>
-        delete_metric_descriptor                     <descriptor_name>
+        delete_metric_descriptor                     <project_id> <descriptor_name>
         write_time_series                            <project_id>
         list_time_series                             <project_id>
         list_time_series_header                      <project_id>

--- a/monitoring/metrics.rb
+++ b/monitoring/metrics.rb
@@ -24,7 +24,7 @@ end
 def delete_metric_descriptor project_id:, descriptor_name:
   # [START monitoring_delete_metric]
   client = Google::Cloud::Monitoring::Metric.new
-  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.metric_descriptor_path(project_id, descriptor_name)
+  project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.metric_descriptor_path project_id, descriptor_name
 
   client.delete_metric_descriptor project_name
   p "Deleted metric descriptor #{descriptor_name}."

--- a/monitoring/metrics.rb
+++ b/monitoring/metrics.rb
@@ -23,6 +23,8 @@ end
 
 def delete_metric_descriptor project_id:, descriptor_name:
   # [START monitoring_delete_metric]
+  # project_id: the text identifer of you Google Cloud project
+  # descriptor_name: the text name of the descriptor (eg: 'run.googleapis.com/request_count')
   client = Google::Cloud::Monitoring::Metric.new
   project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.metric_descriptor_path project_id, descriptor_name
 


### PR DESCRIPTION
Prior to this commit, the function would throw an exception with the following
trace:
```
Traceback (most recent call last):
	11: from monitoring/metrics.rb:213:in `<main>'
	10: from monitoring/metrics.rb:27:in `delete_metric_descriptor'
	 9: from /Library/Ruby/Gems/2.6.0/gems/google-cloud-monitoring-0.35.0/lib/google/cloud/monitoring/v3/metric_service_client.rb:579:in `delete_metric_descriptor'
	 8: from /Library/Ruby/Gems/2.6.0/gems/google-gax-1.8.1/lib/google/gax/api_callable.rb:260:in `block in create_api_call'
	 7: from /Library/Ruby/Gems/2.6.0/gems/google-gax-1.8.1/lib/google/gax/api_callable.rb:230:in `block in create_api_call'
	 6: from /Library/Ruby/Gems/2.6.0/gems/google-gax-1.8.1/lib/google/gax/api_callable.rb:363:in `block in retryable'
	 5: from /Library/Ruby/Gems/2.6.0/gems/grpc-1.27.0-universal-darwin/src/ruby/lib/grpc/generic/client_stub.rb:171:in `block in request_response'
	 4: from /Library/Ruby/Gems/2.6.0/gems/grpc-1.27.0-universal-darwin/src/ruby/lib/grpc/generic/interceptors.rb:170:in `intercept!'
	 3: from /Library/Ruby/Gems/2.6.0/gems/grpc-1.27.0-universal-darwin/src/ruby/lib/grpc/generic/client_stub.rb:172:in `block (2 levels) in request_response'
	 2: from /Library/Ruby/Gems/2.6.0/gems/grpc-1.27.0-universal-darwin/src/ruby/lib/grpc/generic/active_call.rb:377:in `request_response'
	 1: from /Library/Ruby/Gems/2.6.0/gems/grpc-1.27.0-universal-darwin/src/ruby/lib/grpc/generic/active_call.rb:181:in `attach_status_results_and_complete_call'
/Library/Ruby/Gems/2.6.0/gems/grpc-1.27.0-universal-darwin/src/ruby/lib/grpc/generic/active_call.rb:31:in `check_status': 3:Name must begin with 'projects/'. (GRPC::InvalidArgument)
	6: from monitoring/metrics.rb:213:in `<main>'
	5: from monitoring/metrics.rb:27:in `delete_metric_descriptor'
	4: from /Library/Ruby/Gems/2.6.0/gems/google-cloud-monitoring-0.35.0/lib/google/cloud/monitoring/v3/metric_service_client.rb:579:in `delete_metric_descriptor'
	3: from /Library/Ruby/Gems/2.6.0/gems/google-gax-1.8.1/lib/google/gax/api_callable.rb:260:in `block in create_api_call'
	2: from /Library/Ruby/Gems/2.6.0/gems/google-gax-1.8.1/lib/google/gax/api_callable.rb:230:in `block in create_api_call'
	1: from /Library/Ruby/Gems/2.6.0/gems/google-gax-1.8.1/lib/google/gax/api_callable.rb:358:in `block in retryable'
/Library/Ruby/Gems/2.6.0/gems/google-gax-1.8.1/lib/google/gax/api_callable.rb:369:in `rescue in block in retryable': GaxError Exception occurred in retry method that was not classified as transient, caused by 3:Name must begin with 'projects/'. (Google::Gax::RetryError)
```