### PR TITLE
Securitycenter notification samples

### DIFF
--- a/securitycenter/.rspec
+++ b/securitycenter/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/securitycenter/Gemfile
+++ b/securitycenter/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "google-cloud-security_center"
 
 group :test do
+  gem "google-gax"
   gem "rspec"
   gem "rspec-retry"
-  gem "google-gax"
 end

--- a/securitycenter/Gemfile
+++ b/securitycenter/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "google-cloud-security_center"
+
+group :test do
+  gem "rspec"
+  gem "rspec-retry"
+  gem "google-gax"
+end

--- a/securitycenter/Gemfile.lock
+++ b/securitycenter/Gemfile.lock
@@ -1,0 +1,78 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    diff-lcs (1.3)
+    faraday (1.0.0)
+      multipart-post (>= 1.2, < 3)
+    google-cloud-security_center (0.8.0)
+      google-gax (~> 1.8)
+      googleapis-common-protos (>= 1.3.9, < 2.0)
+      googleapis-common-protos-types (>= 1.0.4, < 2.0)
+      grpc-google-iam-v1 (~> 0.6.9)
+    google-gax (1.8.1)
+      google-protobuf (~> 3.9)
+      googleapis-common-protos (>= 1.3.9, < 2.0)
+      googleauth (~> 0.9)
+      grpc (~> 1.24)
+      rly (~> 0.2.3)
+    google-protobuf (3.11.4)
+    googleapis-common-protos (1.3.9)
+      google-protobuf (~> 3.0)
+      googleapis-common-protos-types (~> 1.0)
+      grpc (~> 1.0)
+    googleapis-common-protos-types (1.0.4)
+      google-protobuf (~> 3.0)
+    googleauth (0.11.0)
+      faraday (>= 0.17.3, < 2.0)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.12)
+    grpc (1.27.0)
+      google-protobuf (~> 3.11)
+      googleapis-common-protos-types (~> 1.0)
+    grpc-google-iam-v1 (0.6.9)
+      googleapis-common-protos (>= 1.3.1, < 2.0)
+      grpc (~> 1.0)
+    jwt (2.2.1)
+    memoist (0.16.2)
+    multi_json (1.14.1)
+    multipart-post (2.1.1)
+    os (1.0.1)
+    public_suffix (4.0.3)
+    rly (0.2.3)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
+    rspec-support (3.9.2)
+    signet (0.13.0)
+      addressable (~> 2.3)
+      faraday (>= 0.17.3, < 2.0)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-cloud-security_center
+  google-gax
+  rspec
+  rspec-retry
+
+BUNDLED WITH
+   2.1.4

--- a/securitycenter/Gemfile.lock
+++ b/securitycenter/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     diff-lcs (1.3)
     faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
-    google-cloud-security_center (0.8.0)
+    google-cloud-security_center (0.9.0)
       google-gax (~> 1.8)
       googleapis-common-protos (>= 1.3.9, < 2.0)
       googleapis-common-protos-types (>= 1.0.4, < 2.0)
@@ -50,7 +50,7 @@ GEM
       rspec-mocks (~> 3.9.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.0)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-mocks (3.9.1)
@@ -75,4 +75,4 @@ DEPENDENCIES
   rspec-retry
 
 BUNDLED WITH
-   2.1.4
+   1.17.2

--- a/securitycenter/README.md
+++ b/securitycenter/README.md
@@ -1,0 +1,60 @@
+<img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
+
+# Google Cloud Security Command Center Ruby Samples
+
+[Google Cloud Security Command Center][language_docs] is a comprehensive security management and data risk platform for Google Cloud.
+
+[language_docs]: https://cloud.google.com/security-command-center/docs
+
+## Setup
+
+### Authentication
+
+Authentication is typically done through [Application Default Credentials](https://cloud.google.com/docs/authentication#getting_credentials_for_server-centric_flow)
+, which means you do not have to change the code to authenticate as long as your
+environment has credentials. You have a few options for setting up
+authentication:
+
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+
+    `gcloud auth application-default login`
+
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
+. This file can be used to authenticate to Google Cloud Platform services from
+any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable to the path to the key file, for example:
+
+    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+
+### Install Dependencies
+
+1. Install the [Bundler](http://bundler.io) gem.
+
+1. Install dependencies using:
+
+    `bundle install`
+
+## Run Samples
+
+Run the sample for using topics:
+
+    bundle exec ruby notification.rb
+
+    Usage: bundle exec ruby notification.rb [command] [arguments]
+
+    Commands:
+      create_notification_config  <org_id> <config_id> <pubsub_topic>                Creates a Notification config
+      delete_notification_config  <org_id> <config_id>                               Deletes a Notification config
+      get_notification_config     <org_id> <config_id>                               Fetches a Notification config
+      update_notification_config  <org_id> <config_id> <description> <pubsub_topic>  Updates a Notification config
+      list_notification_configs   <org_id>                                           Lists Notification configs in an organization
+
+For example:
+
+    create_notification_config 123 config-id projects/my-project/topics/my-topic
+
+## Test samples
+
+Test the sample:
+
+    bundle exec rspec

--- a/securitycenter/notification.rb
+++ b/securitycenter/notification.rb
@@ -8,17 +8,17 @@ def create_notification_config org_id:, config_id:, pubsub_topic:
   #               "organizations/123/notificationConfigs/my-config",
   #               this would be "my-config".
   # pubsub_topic: Pubsub topic that Notifications will be published to.
-  securitycenter = Google::Cloud::SecurityCenter.new()
+  securitycenter = Google::Cloud::SecurityCenter.new
 
-  formatted_parent = securitycenter.organization_path(org_id)
+  formatted_parent = securitycenter.organization_path org_id
 
   notification_config = {
-    description: 'Sample config for Ruby',
-    pubsub_topic: pubsub_topic,
-    streaming_config: {filter: 'state = "ACTIVE"'},
+    description:      "Sample config for Ruby",
+    pubsub_topic:     pubsub_topic,
+    streaming_config: { filter: 'state = "ACTIVE"' }
   }
 
-  response = securitycenter.create_notification_config(formatted_parent, config_id, notification_config)
+  response = securitycenter.create_notification_config formatted_parent, config_id, notification_config
   puts "Created notification config #{config_id}: #{response}. "
 end
 # [END scc_create_notification_config]
@@ -26,11 +26,7 @@ end
 # [START scc_update_notification_config]
 require "google/cloud/security_center"
 
-def update_notification_config \
-  org_id:,
-  config_id:,
-  description: nil,
-  pubsub_topic: nil
+def update_notification_config org_id:, config_id:, description: nil, pubsub_topic: nil
   # org_id:       Your organization id. e.g. for organizations/123, this would
   #               be 123.
   # config_id:    Your notification config id. e.g. for config id
@@ -38,31 +34,31 @@ def update_notification_config \
   #               this would be "my-config".
   # description:  Updated description of the Notification config.
   # pubsub_topic: Updated pubsub topic for the Notification config.
-  securitycenter = Google::Cloud::SecurityCenter.new()
+  securitycenter = Google::Cloud::SecurityCenter.new
 
-  formatted_config_id = securitycenter.notification_config_path(org_id, config_id)
+  formatted_config_id = securitycenter.notification_config_path org_id, config_id
 
   notification_config = {
-    name: formatted_config_id,
+    name: formatted_config_id
   }
-  if !description.nil?
+  unless description.nil?
     notification_config[:description] = description
   end
-  if !pubsub_topic.nil?
+  unless pubsub_topic.nil?
     notification_config[:pubsub_topic] = pubsub_topic
   end
 
   update_mask = {
-    paths: [],
+    paths: []
   }
-  if !description.nil?
-    update_mask[:paths].push("description")
+  unless description.nil?
+    update_mask[:paths].push "description"
   end
-  if !pubsub_topic.nil?
-    update_mask[:paths].push("pubsub_topic")
+  unless pubsub_topic.nil?
+    update_mask[:paths].push "pubsub_topic"
   end
 
-  response = securitycenter.update_notification_config(notification_config, update_mask: update_mask)
+  response = securitycenter.update_notification_config notification_config, update_mask: update_mask
   puts response
 end
 # [END scc_update_notification_config]
@@ -76,11 +72,11 @@ def delete_notification_config org_id:, config_id:
   # config_id:    Your notification config id. e.g. for config id
   #               "organizations/123/notificationConfigs/my-config",
   #               this would be "my-config".
-  securitycenter = Google::Cloud::SecurityCenter.new()
+  securitycenter = Google::Cloud::SecurityCenter.new
 
-  formatted_config_id = securitycenter.notification_config_path(org_id, config_id)
+  formatted_config_id = securitycenter.notification_config_path org_id, config_id
 
-  response = securitycenter.delete_notification_config(formatted_config_id)
+  response = securitycenter.delete_notification_config formatted_config_id
   puts "Deleted notification config: #{config_id}"
 end
 # [END scc_delete_notification_config]
@@ -94,11 +90,11 @@ def get_notification_config org_id:, config_id:
   # config_id:    Your notification config id. e.g. for config id
   #               "organizations/123/notificationConfigs/my-config",
   #               this would be "my-config".
-  securitycenter = Google::Cloud::SecurityCenter.new()
+  securitycenter = Google::Cloud::SecurityCenter.new
 
-  formatted_config_id = securitycenter.notification_config_path(org_id, config_id)
+  formatted_config_id = securitycenter.notification_config_path org_id, config_id
 
-  response = securitycenter.get_notification_config(formatted_config_id)
+  response = securitycenter.get_notification_config formatted_config_id
   puts "Notification config fetched: #{response}"
 end
 # [END scc_get_notification_config]
@@ -109,9 +105,9 @@ require "google/cloud/security_center"
 def list_notification_configs org_id:
   # org_id: Your organization id. e.g. for organizations/123, this would
   #         be 123.
-  securitycenter = Google::Cloud::SecurityCenter.new()
+  securitycenter = Google::Cloud::SecurityCenter.new
 
-  formatted_parent = securitycenter.organization_path(org_id)
+  formatted_parent = securitycenter.organization_path org_id
 
   securitycenter.list_notification_configs(formatted_parent).each_page do |page|
     page.each do |element|
@@ -124,19 +120,19 @@ end
 if $PROGRAM_NAME == __FILE__
   case ARGV.shift
   when "create_notification_config"
-    create_notification_config org_id: ARGV.shift,
-                               config_id: ARGV.shift,
+    create_notification_config org_id:       ARGV.shift,
+                               config_id:    ARGV.shift,
                                pubsub_topic: ARGV.shift
   when "delete_notification_config"
-    delete_notification_config org_id: ARGV.shift,
+    delete_notification_config org_id:    ARGV.shift,
                                config_id: ARGV.shift
   when "update_notification_config"
-    update_notification_config org_id: ARGV.shift,
-                               config_id: ARGV.shift,
-                               description: ARGV.shift,
+    update_notification_config org_id:       ARGV.shift,
+                               config_id:    ARGV.shift,
+                               description:  ARGV.shift,
                                pubsub_topic: ARGV.shift
   when "get_notification_config"
-    get_notification_config org_id: ARGV.shift,
+    get_notification_config org_id:    ARGV.shift,
                             config_id: ARGV.shift
 
   when "list_notification_configs"

--- a/securitycenter/notification.rb
+++ b/securitycenter/notification.rb
@@ -1,7 +1,7 @@
-# [START scc_create_notification_config]
-require "google/cloud/security_center"
-
 def create_notification_config org_id:, config_id:, pubsub_topic:
+  # [START scc_create_notification_config]
+  require "google/cloud/security_center"
+  
   # org_id:       Your organization id. e.g. for organizations/123, this would
   #               be 123.
   # config_id:    Your notification config id. e.g. for config id
@@ -20,13 +20,13 @@ def create_notification_config org_id:, config_id:, pubsub_topic:
 
   response = securitycenter.create_notification_config formatted_parent, config_id, notification_config
   puts "Created notification config #{config_id}: #{response}. "
+  # [END scc_create_notification_config]
 end
-# [END scc_create_notification_config]
-
-# [START scc_update_notification_config]
-require "google/cloud/security_center"
 
 def update_notification_config org_id:, config_id:, description: nil, pubsub_topic: nil
+  # [START scc_update_notification_config]
+  require "google/cloud/security_center"
+  
   # org_id:       Your organization id. e.g. for organizations/123, this would
   #               be 123.
   # config_id:    Your notification config id. e.g. for config id
@@ -60,13 +60,13 @@ def update_notification_config org_id:, config_id:, description: nil, pubsub_top
 
   response = securitycenter.update_notification_config notification_config, update_mask: update_mask
   puts response
+  # [END scc_update_notification_config]
 end
-# [END scc_update_notification_config]
-
-# [START scc_delete_notification_config]
-require "google/cloud/security_center"
 
 def delete_notification_config org_id:, config_id:
+  # [START scc_delete_notification_config]
+  require "google/cloud/security_center"
+
   # org_id:       Your organization id. e.g. for organizations/123, this would
   #               be 123.
   # config_id:    Your notification config id. e.g. for config id
@@ -78,13 +78,13 @@ def delete_notification_config org_id:, config_id:
 
   response = securitycenter.delete_notification_config formatted_config_id
   puts "Deleted notification config: #{config_id}"
+  # [END scc_delete_notification_config]
 end
-# [END scc_delete_notification_config]
-
-# [START scc_get_notification_config]
-require "google/cloud/security_center"
 
 def get_notification_config org_id:, config_id:
+  # [START scc_get_notification_config]
+  require "google/cloud/security_center"
+  
   # org_id:       Your organization id. e.g. for organizations/123, this would
   #               be 123.
   # config_id:    Your notification config id. e.g. for config id
@@ -96,13 +96,13 @@ def get_notification_config org_id:, config_id:
 
   response = securitycenter.get_notification_config formatted_config_id
   puts "Notification config fetched: #{response}"
+  # [END scc_get_notification_config]
 end
-# [END scc_get_notification_config]
-
-# [START scc_list_notification_configs]
-require "google/cloud/security_center"
 
 def list_notification_configs org_id:
+  # [START scc_list_notification_configs]
+  require "google/cloud/security_center"
+  
   # org_id: Your organization id. e.g. for organizations/123, this would
   #         be 123.
   securitycenter = Google::Cloud::SecurityCenter.new
@@ -114,8 +114,8 @@ def list_notification_configs org_id:
       puts element
     end
   end
+  # [END scc_list_notification_configs]
 end
-# [END scc_list_notification_configs]
 
 if $PROGRAM_NAME == __FILE__
   case ARGV.shift

--- a/securitycenter/notification.rb
+++ b/securitycenter/notification.rb
@@ -1,0 +1,156 @@
+# [START scc_create_notification_config]
+require "google/cloud/security_center"
+
+def create_notification_config org_id:, config_id:, pubsub_topic:
+  # org_id:       Your organization id. e.g. for organizations/123, this would
+  #               be 123.
+  # config_id:    Your notification config id. e.g. for config id
+  #               "organizations/123/notificationConfigs/my-config",
+  #               this would be "my-config".
+  # pubsub_topic: Pubsub topic that Notifications will be published to.
+  securitycenter = Google::Cloud::SecurityCenter.new()
+
+  formatted_parent = securitycenter.organization_path(org_id)
+
+  notification_config = {
+    description: 'Sample config for Ruby',
+    pubsub_topic: pubsub_topic,
+    streaming_config: {filter: 'state = "ACTIVE"'},
+  }
+
+  response = securitycenter.create_notification_config(formatted_parent, config_id, notification_config)
+  puts "Created notification config #{config_id}: #{response}. "
+end
+# [END scc_create_notification_config]
+
+# [START scc_update_notification_config]
+require "google/cloud/security_center"
+
+def update_notification_config \
+  org_id:,
+  config_id:,
+  description: nil,
+  pubsub_topic: nil
+  # org_id:       Your organization id. e.g. for organizations/123, this would
+  #               be 123.
+  # config_id:    Your notification config id. e.g. for config id
+  #               "organizations/123/notificationConfigs/my-config",
+  #               this would be "my-config".
+  # description:  Updated description of the Notification config.
+  # pubsub_topic: Updated pubsub topic for the Notification config.
+  securitycenter = Google::Cloud::SecurityCenter.new()
+
+  formatted_config_id = securitycenter.notification_config_path(org_id, config_id)
+
+  notification_config = {
+    name: formatted_config_id,
+  }
+  if !description.nil?
+    notification_config[:description] = description
+  end
+  if !pubsub_topic.nil?
+    notification_config[:pubsub_topic] = pubsub_topic
+  end
+
+  update_mask = {
+    paths: [],
+  }
+  if !description.nil?
+    update_mask[:paths].push("description")
+  end
+  if !pubsub_topic.nil?
+    update_mask[:paths].push("pubsub_topic")
+  end
+
+  response = securitycenter.update_notification_config(notification_config, update_mask: update_mask)
+  puts response
+end
+# [END scc_update_notification_config]
+
+# [START scc_delete_notification_config]
+require "google/cloud/security_center"
+
+def delete_notification_config org_id:, config_id:
+  # org_id:       Your organization id. e.g. for organizations/123, this would
+  #               be 123.
+  # config_id:    Your notification config id. e.g. for config id
+  #               "organizations/123/notificationConfigs/my-config",
+  #               this would be "my-config".
+  securitycenter = Google::Cloud::SecurityCenter.new()
+
+  formatted_config_id = securitycenter.notification_config_path(org_id, config_id)
+
+  response = securitycenter.delete_notification_config(formatted_config_id)
+  puts "Deleted notification config: #{config_id}"
+end
+# [END scc_delete_notification_config]
+
+# [START scc_get_notification_config]
+require "google/cloud/security_center"
+
+def get_notification_config org_id:, config_id:
+  # org_id:       Your organization id. e.g. for organizations/123, this would
+  #               be 123.
+  # config_id:    Your notification config id. e.g. for config id
+  #               "organizations/123/notificationConfigs/my-config",
+  #               this would be "my-config".
+  securitycenter = Google::Cloud::SecurityCenter.new()
+
+  formatted_config_id = securitycenter.notification_config_path(org_id, config_id)
+
+  response = securitycenter.get_notification_config(formatted_config_id)
+  puts "Notification config fetched: #{response}"
+end
+# [END scc_get_notification_config]
+
+# [START scc_list_notification_configs]
+require "google/cloud/security_center"
+
+def list_notification_configs org_id:
+  # org_id: Your organization id. e.g. for organizations/123, this would
+  #         be 123.
+  securitycenter = Google::Cloud::SecurityCenter.new()
+
+  formatted_parent = securitycenter.organization_path(org_id)
+
+  securitycenter.list_notification_configs(formatted_parent).each_page do |page|
+    page.each do |element|
+      puts element
+    end
+  end
+end
+# [END scc_list_notification_configs]
+
+if $PROGRAM_NAME == __FILE__
+  case ARGV.shift
+  when "create_notification_config"
+    create_notification_config org_id: ARGV.shift,
+                               config_id: ARGV.shift,
+                               pubsub_topic: ARGV.shift
+  when "delete_notification_config"
+    delete_notification_config org_id: ARGV.shift,
+                               config_id: ARGV.shift
+  when "update_notification_config"
+    update_notification_config org_id: ARGV.shift,
+                               config_id: ARGV.shift,
+                               description: ARGV.shift,
+                               pubsub_topic: ARGV.shift
+  when "get_notification_config"
+    get_notification_config org_id: ARGV.shift,
+                            config_id: ARGV.shift
+
+  when "list_notification_configs"
+    list_notification_configs org_id: ARGV.shift
+  else
+    puts <<~USAGE
+      Usage: bundle exec ruby notification.rb [command] [arguments]
+
+      Commands:
+        create_notification_config  <org_id> <config_id> <pubsub_topic>                Creates a Notification config
+        delete_notification_config  <org_id> <config_id>                               Deletes a Notification config
+        get_notification_config     <org_id> <config_id>                               Fetches a Notification config
+        update_notification_config  <org_id> <config_id> <description> <pubsub_topic>  Updates a Notification config
+        list_notification_configs   <org_id>                                           Lists Notification configs in an organization
+    USAGE
+  end
+end

--- a/securitycenter/notification.rb
+++ b/securitycenter/notification.rb
@@ -1,7 +1,9 @@
+require "google/cloud/security_center"
+
 def create_notification_config org_id:, config_id:, pubsub_topic:
   # [START scc_create_notification_config]
   require "google/cloud/security_center"
-  
+
   # org_id:       Your organization id. e.g. for organizations/123, this would
   #               be 123.
   # config_id:    Your notification config id. e.g. for config id
@@ -26,7 +28,7 @@ end
 def update_notification_config org_id:, config_id:, description: nil, pubsub_topic: nil
   # [START scc_update_notification_config]
   require "google/cloud/security_center"
-  
+
   # org_id:       Your organization id. e.g. for organizations/123, this would
   #               be 123.
   # config_id:    Your notification config id. e.g. for config id
@@ -84,7 +86,7 @@ end
 def get_notification_config org_id:, config_id:
   # [START scc_get_notification_config]
   require "google/cloud/security_center"
-  
+
   # org_id:       Your organization id. e.g. for organizations/123, this would
   #               be 123.
   # config_id:    Your notification config id. e.g. for config id
@@ -102,7 +104,7 @@ end
 def list_notification_configs org_id:
   # [START scc_list_notification_configs]
   require "google/cloud/security_center"
-  
+
   # org_id: Your organization id. e.g. for organizations/123, this would
   #         be 123.
   securitycenter = Google::Cloud::SecurityCenter.new

--- a/securitycenter/spec/notification_spec.rb
+++ b/securitycenter/spec/notification_spec.rb
@@ -1,0 +1,92 @@
+require "google/gax"
+require "rspec/retry"
+require_relative "spec_helper"
+require_relative "../notification"
+
+RSpec.configure do |config|
+  # show retry status in spec process
+  config.verbose_retry = true
+  # show exception that triggers a retry if verbose_retry is set to true
+  config.display_try_failure_messages = true
+
+  # set retry count and retry sleep interval to 5 tries and 5 seconds
+  config.default_retry_count = 5
+  config.default_sleep_interval = 5
+end
+
+describe "Google Cloud Security Center Notifications Sample" do
+  before do
+    @securitycenter = Google::Cloud::SecurityCenter.new()
+    @pubsub_topic   = "projects/project-a-id/topics/notifications-sample-topic"
+    @config_id      = "config-id"
+    @org_id         = "1081635000895"
+    @formatted_config_id = @securitycenter.notification_config_path(@org_id, @config_id)
+
+    cleanup!
+  end
+
+  after do
+    cleanup!
+  end
+
+  def cleanup!
+    begin
+      @securitycenter.delete_notification_config(@formatted_config_id)
+    rescue Google::Gax::NotFoundError
+      # do nothing, means config was already cleaned up
+    end
+  end
+
+  it "creates notification config" do
+    expect {
+      create_notification_config org_id: @org_id,
+                                 config_id: @config_id,
+                                 pubsub_topic: @pubsub_topic
+    }.to output(/Created notification config #{@config_id}/).to_stdout
+
+    config = @securitycenter.get_notification_config(@formatted_config_id)
+    expect(config.name).to eq(@formatted_config_id)
+  end
+
+  it "updates notification config" do
+    create_notification_config org_id: @org_id,
+                               config_id: @config_id,
+                               pubsub_topic: @pubsub_topic
+    expect {
+      update_notification_config org_id: @org_id,
+                                config_id: @config_id,
+                                description: "Updated description"
+    }.to output(/Updated description/).to_stdout
+  end
+
+  it "deletes notification config" do
+    create_notification_config org_id: @org_id,
+                               config_id: @config_id,
+                               pubsub_topic: @pubsub_topic
+
+    expect {
+      delete_notification_config org_id: @org_id,
+                                 config_id: @config_id
+    }.to output(/Deleted notification config: #{@config_id}/).to_stdout
+  end
+
+  it "gets notification config" do
+      create_notification_config org_id: @org_id,
+                                 config_id: @config_id,
+                                 pubsub_topic: @pubsub_topic
+      expect {
+        get_notification_config  org_id: @org_id,
+                                 config_id: @config_id
+      }.to output(/#{@formatted_config_id}/).to_stdout
+  end
+
+  it "lists notification configs" do
+      create_notification_config org_id: @org_id,
+                                 config_id: @config_id,
+                                 pubsub_topic: @pubsub_topic
+
+      expect {
+        list_notification_configs org_id: @org_id
+      }.to output(/#{@formatted_config_id}/).to_stdout
+  end
+end

--- a/securitycenter/spec/notification_spec.rb
+++ b/securitycenter/spec/notification_spec.rb
@@ -16,11 +16,11 @@ end
 
 describe "Google Cloud Security Center Notifications Sample" do
   before do
-    @securitycenter = Google::Cloud::SecurityCenter.new()
+    @securitycenter = Google::Cloud::SecurityCenter.new
     @pubsub_topic   = "projects/project-a-id/topics/notifications-sample-topic"
     @config_id      = "config-id"
     @org_id         = "1081635000895"
-    @formatted_config_id = @securitycenter.notification_config_path(@org_id, @config_id)
+    @formatted_config_id = @securitycenter.notification_config_path @org_id, @config_id
 
     cleanup!
   end
@@ -30,63 +30,61 @@ describe "Google Cloud Security Center Notifications Sample" do
   end
 
   def cleanup!
-    begin
-      @securitycenter.delete_notification_config(@formatted_config_id)
-    rescue Google::Gax::NotFoundError
-      # do nothing, means config was already cleaned up
-    end
+    @securitycenter.delete_notification_config @formatted_config_id
+  rescue Google::Gax::NotFoundError
+    puts "Config #{@formatted_config_id} already deleted"
   end
 
   it "creates notification config" do
     expect {
-      create_notification_config org_id: @org_id,
-                                 config_id: @config_id,
+      create_notification_config org_id:       @org_id,
+                                 config_id:    @config_id,
                                  pubsub_topic: @pubsub_topic
     }.to output(/Created notification config #{@config_id}/).to_stdout
 
-    config = @securitycenter.get_notification_config(@formatted_config_id)
+    config = @securitycenter.get_notification_config @formatted_config_id
     expect(config.name).to eq(@formatted_config_id)
   end
 
   it "updates notification config" do
-    create_notification_config org_id: @org_id,
-                               config_id: @config_id,
+    create_notification_config org_id:       @org_id,
+                               config_id:    @config_id,
                                pubsub_topic: @pubsub_topic
     expect {
-      update_notification_config org_id: @org_id,
-                                config_id: @config_id,
-                                description: "Updated description"
+      update_notification_config org_id:      @org_id,
+                                 config_id:   @config_id,
+                                 description: "Updated description"
     }.to output(/Updated description/).to_stdout
   end
 
   it "deletes notification config" do
-    create_notification_config org_id: @org_id,
-                               config_id: @config_id,
+    create_notification_config org_id:       @org_id,
+                               config_id:    @config_id,
                                pubsub_topic: @pubsub_topic
 
     expect {
-      delete_notification_config org_id: @org_id,
+      delete_notification_config org_id:    @org_id,
                                  config_id: @config_id
     }.to output(/Deleted notification config: #{@config_id}/).to_stdout
   end
 
   it "gets notification config" do
-      create_notification_config org_id: @org_id,
-                                 config_id: @config_id,
-                                 pubsub_topic: @pubsub_topic
-      expect {
-        get_notification_config  org_id: @org_id,
-                                 config_id: @config_id
-      }.to output(/#{@formatted_config_id}/).to_stdout
+    create_notification_config org_id:       @org_id,
+                               config_id:    @config_id,
+                               pubsub_topic: @pubsub_topic
+    expect {
+      get_notification_config  org_id:    @org_id,
+                               config_id: @config_id
+    }.to output(/#{@formatted_config_id}/).to_stdout
   end
 
   it "lists notification configs" do
-      create_notification_config org_id: @org_id,
-                                 config_id: @config_id,
-                                 pubsub_topic: @pubsub_topic
+    create_notification_config org_id:       @org_id,
+                               config_id:    @config_id,
+                               pubsub_topic: @pubsub_topic
 
-      expect {
-        list_notification_configs org_id: @org_id
-      }.to output(/#{@formatted_config_id}/).to_stdout
+    expect {
+      list_notification_configs org_id: @org_id
+    }.to output(/#{@formatted_config_id}/).to_stdout
   end
 end

--- a/securitycenter/spec/spec_helper.rb
+++ b/securitycenter/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require "rspec"


### PR DESCRIPTION
Hi! 

This is to add Notifications samples to the Security Center docs in preparation for GA.

I have a question about the expectation / process for unit tests. I didn't see much guidance in the internal documentation on how to do this. What I've done is written integration tests that actually hit production when run for each of the CRUD methods. Do these tests run as part of a CI build, or is this entirely user driven?

If the former, I think we need to add the service account(s) that will be used to authenticate when hitting the Security Center API for the project .org specified in the tests. If it's the latter, users will need to tweak the org_id to be whatever org they're using, and make sure to follow instructions on authenticating their application default credentials.

Let me know how to proceed on tests.

