### PR TITLE
fix: Update Ruby GCF samples to Functions Framework 0.3

### DIFF
--- a/functions/Gemfile
+++ b/functions/Gemfile
@@ -14,7 +14,7 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.1"
+gem "functions_framework", "~> 0.3"
 
 group "test" do
   gem "minitest", "~> 5.14"

--- a/functions/helloworld/pubsub.rb
+++ b/functions/helloworld/pubsub.rb
@@ -19,7 +19,7 @@ require "base64"
 FunctionsFramework.cloud_event "hello-pubsub" do |event|
   # The event parameter is a FunctionsFramework::CloudEvents::Event object.
   # See https://www.rubydoc.info/gems/functions_framework/FunctionsFramework/CloudEvents/Event
-  name = Base64.decode64 event.data["data"] rescue "World"
+  name = Base64.decode64 event.data["message"]["data"] rescue "World"
   # A background function does not return a response, but you can log messages
   # or cause side effects such as sending additional events.
   FunctionsFramework.logger.info "Hello, #{name}!"

--- a/functions/test/helloworld/pubsub_test.rb
+++ b/functions/test/helloworld/pubsub_test.rb
@@ -24,7 +24,7 @@ describe "functions_helloworld_pubsub" do
 
   it "handles name in pubsub payload" do
     load_temporary "helloworld/pubsub.rb" do
-      payload = { "@type" => resource_type, "data" => Base64.encode64("Ruby") }
+      payload = { "@type" => resource_type, "message" => { "data" => Base64.encode64("Ruby") } }
       event = make_cloud_event payload, source: source, type: type
       _out, err = capture_subprocess_io do
         call_event "hello-pubsub", event
@@ -35,7 +35,7 @@ describe "functions_helloworld_pubsub" do
 
   it "uses a default name" do
     load_temporary "helloworld/pubsub.rb" do
-      payload = { "@type" => resource_type }
+      payload = { "@type" => resource_type, "message" => { "data" => nil } }
       event = make_cloud_event payload, source: source, type: type
       _out, err = capture_subprocess_io do
         call_event "hello-pubsub", event


### PR DESCRIPTION
The Ruby Functions Framework 0.3 changed the data format for converted legacy PubSub events. (This change was agreed across languages.) This PR updates the pubsub sample accordingly.