### PR TITLE
feat: add samples for http cors

### DIFF
--- a/functions/http/cors.rb
+++ b/functions/http/cors.rb
@@ -15,13 +15,13 @@
 require "functions_framework"
 
 # [START functions_http_cors]
-FunctionsFramework.http "cors_enabled_function" do |_request|
+FunctionsFramework.http "cors_enabled_function" do |request|
   # For more information about CORS and CORS preflight requests, see
   # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
   # for more information.
 
   # Set CORS headers for the preflight request
-  if _request.options?
+  if request.options?
     # Allows GET requests from any origin with the Content-Type
     # header and caches preflight response for an 3600s
     headers = {
@@ -43,13 +43,13 @@ end
 # [END functions_http_cors]
 
 # [START functions_http_cors_auth]
-FunctionsFramework.http "cors_enabled_function_auth" do |_request|
+FunctionsFramework.http "cors_enabled_function_auth" do |request|
   # For more information about CORS and CORS preflight requests, see
   # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
   # for more information.
 
   # Set CORS headers for preflight requests
-  if _request.options?
+  if request.options?
     # Allows GET requests from origin https://mydomain.com with
     # Authorization header
     headers = {

--- a/functions/http/cors.rb
+++ b/functions/http/cors.rb
@@ -1,0 +1,73 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "functions_framework"
+
+# [START functions_http_cors]
+FunctionsFramework.http "cors_enabled_function" do |_request|
+  # For more information about CORS and CORS preflight requests, see
+  # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+  # for more information.
+
+  # Set CORS headers for the preflight request
+  if _request.options?
+    # Allows GET requests from any origin with the Content-Type
+    # header and caches preflight response for an 3600s
+    headers = {
+      "Access-Control-Allow-Origin"  => "*",
+      "Access-Control-Allow-Methods" => "GET",
+      "Access-Control-Allow-Headers" => "Content-Type",
+      "Access-Control-Max-Age"       => "3600"
+    }
+    [204, headers, []]
+  else
+    # Set CORS headers for the main request
+    headers = {
+      "Access-Control-Allow-Origin" => "*"
+    }
+
+    [200, headers, ["Hello World!"]]
+  end
+end
+# [END functions_http_cors]
+
+# [START functions_http_cors_auth]
+FunctionsFramework.http "cors_enabled_function_auth" do |_request|
+  # For more information about CORS and CORS preflight requests, see
+  # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+  # for more information.
+
+  # Set CORS headers for preflight requests
+  if _request.options?
+    # Allows GET requests from origin https://mydomain.com with
+    # Authorization header
+    headers = {
+      "Access-Control-Allow-Origin"      => "https://mydomain.com",
+      "Access-Control-Allow-Methods"     => "GET",
+      "Access-Control-Allow-Headers"     => "Authorization",
+      "Access-Control-Max-Age"           => "3600",
+      "Access-Control-Allow-Credentials" => "true"
+    }
+    [204, headers, []]
+  else
+    # Set CORS headers for main requests
+    headers = {
+      "Access-Control-Allow-Origin"      => "https://mydomain.com",
+      "Access-Control-Allow-Credentials" => "true"
+    }
+
+    [200, headers, ["Hello World!"]]
+  end
+end
+# [END functions_http_cors_auth]

--- a/functions/test/http/cors_test.rb
+++ b/functions/test/http/cors_test.rb
@@ -1,0 +1,75 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+##
+# Make a simple OPTIONS request, for passing to a function test.
+#
+# @param url [URI,String] The URL to get.
+# @return [Rack::Request]
+#
+def make_options_request url, headers = []
+  env = ::FunctionsFramework::Testing.build_standard_env URI(url), headers
+  env[::Rack::REQUEST_METHOD] = ::Rack::OPTIONS
+  ::Rack::Request.new env
+end
+
+describe "functions_http_cors" do
+  include FunctionsFramework::Testing
+
+  it "handles CORS enabled preflight requests" do
+    load_temporary "http/cors.rb" do
+      request = make_options_request "http://example.com:8080/"
+      response = call_http "cors_enabled_function", request
+      assert_equal 204, response.status
+      assert_equal "*", response.get_header("Access-Control-Allow-Origin")
+      assert_equal "GET", response.get_header("Access-Control-Allow-Methods")
+      assert_equal "Content-Type", response.get_header("Access-Control-Allow-Headers")
+      assert_equal "3600", response.get_header("Access-Control-Max-Age")
+    end
+  end
+
+  it "handles CORS enabled GET requests" do
+    load_temporary "http/cors.rb" do
+      request = make_get_request "http://example.com:8080/"
+      response = call_http "cors_enabled_function", request
+      assert_equal 200, response.status
+      assert_equal "*", response.get_header("Access-Control-Allow-Origin")
+    end
+  end
+
+  it "handles CORS enabled preflight requests with auth enforced" do
+    load_temporary "http/cors.rb" do
+      request = make_options_request "http://example.com:8080/"
+      response = call_http "cors_enabled_function_auth", request
+      assert_equal 204, response.status
+      assert_equal "https://mydomain.com", response.get_header("Access-Control-Allow-Origin")
+      assert_equal "GET", response.get_header("Access-Control-Allow-Methods")
+      assert_equal "Authorization", response.get_header("Access-Control-Allow-Headers")
+      assert_equal "3600", response.get_header("Access-Control-Max-Age")
+      assert_equal "true", response.get_header("Access-Control-Allow-Credentials")
+    end
+  end
+
+  it "handles CORS enabled GET requests with auth enforced" do
+    load_temporary "http/cors.rb" do
+      request = make_get_request "http://example.com:8080/"
+      response = call_http "cors_enabled_function_auth", request
+      assert_equal 200, response.status
+      assert_equal "https://mydomain.com", response.get_header("Access-Control-Allow-Origin")
+      assert_equal "true", response.get_header("Access-Control-Allow-Credentials")
+    end
+  end
+end


### PR DESCRIPTION
Add Functions samples and tests for HTTP CORS requests. This is based on the Python version here: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/1523c225344bd7c38ab3b54e7bccf8ef9e7a3184/functions/http/main.py#L127-L152