### PR TITLE
chore: Update functions_framework dependency to 0.7

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,8 +12,10 @@ def run_tests type
   failed = false
   full_start_time = Time.now
 
+  header "Running on Ruby #{RUBY_VERSION}"
   header "Installing dependencies"
-  each_lib do |_dir|
+  each_lib do |dir|
+    header "Installing bundle in #{dir}"
     sh "bundle update"
   end
 
@@ -28,7 +30,6 @@ def run_tests type
     end
     end_time = Time.now
     header_2 "Tests for #{lib} took #{(end_time - start_time).to_i} seconds"
-    test_task dir, type
   end
 
   full_end_time = Time.now
@@ -68,7 +69,11 @@ def dirs
   entries = Dir.glob("#{__dir__}/**/*_test.rb").map do |entry|
     File.expand_path "..", File.dirname(entry)
   end
-  entries.uniq
+  entries.uniq!
+  if RUBY_VERSION.start_with? "2.4"
+    entries.delete_if { |dir| dir.include? "/ruby-docs-samples/functions" }
+  end
+  entries
 end
 
 def header str, token = "#"

--- a/functions/Gemfile
+++ b/functions/Gemfile
@@ -14,7 +14,7 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"
 
 group "test" do
   gem "minitest", "~> 5.14"

--- a/functions/Gemfile.lock
+++ b/functions/Gemfile.lock
@@ -1,16 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    minitest (5.14.1)
+    minitest (5.14.2)
     minitest-focus (1.2.1)
       minitest (>= 4, < 6)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
     rake (13.0.1)
@@ -19,10 +19,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.3)
+  functions_framework (~> 0.7)
   minitest (~> 5.14)
   minitest-focus (~> 1.1)
   rake (>= 12.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/concepts/filesystem/Gemfile
+++ b/functions/concepts/filesystem/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/concepts/filesystem/Gemfile.lock
+++ b/functions/concepts/filesystem/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/concepts/requests/Gemfile
+++ b/functions/concepts/requests/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/concepts/requests/Gemfile.lock
+++ b/functions/concepts/requests/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/concepts/stateless/Gemfile
+++ b/functions/concepts/stateless/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/concepts/stateless/Gemfile.lock
+++ b/functions/concepts/stateless/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/firebase/firestore/Gemfile
+++ b/functions/firebase/firestore/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/firebase/firestore/Gemfile.lock
+++ b/functions/firebase/firestore/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/helloworld/get/Gemfile
+++ b/functions/helloworld/get/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/helloworld/get/Gemfile.lock
+++ b/functions/helloworld/get/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/helloworld/http/Gemfile
+++ b/functions/helloworld/http/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/helloworld/http/Gemfile.lock
+++ b/functions/helloworld/http/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/helloworld/log/Gemfile
+++ b/functions/helloworld/log/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/helloworld/log/Gemfile.lock
+++ b/functions/helloworld/log/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/helloworld/pubsub/Gemfile
+++ b/functions/helloworld/pubsub/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/helloworld/pubsub/Gemfile.lock
+++ b/functions/helloworld/pubsub/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/helloworld/storage/Gemfile
+++ b/functions/helloworld/storage/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/helloworld/storage/Gemfile.lock
+++ b/functions/helloworld/storage/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/http/content/Gemfile
+++ b/functions/http/content/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/http/content/Gemfile.lock
+++ b/functions/http/content/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/http/cors/Gemfile
+++ b/functions/http/cors/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/http/cors/Gemfile.lock
+++ b/functions/http/cors/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/http/method/Gemfile
+++ b/functions/http/method/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/http/method/Gemfile.lock
+++ b/functions/http/method/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/tips/infinite_retries/Gemfile
+++ b/functions/tips/infinite_retries/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/tips/infinite_retries/Gemfile.lock
+++ b/functions/tips/infinite_retries/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/functions/tips/retry/Gemfile
+++ b/functions/tips/retry/Gemfile
@@ -14,4 +14,4 @@
 
 source "https://rubygems.org"
 
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"

--- a/functions/tips/retry/Gemfile.lock
+++ b/functions/tips/retry/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cloud_events (0.1.1)
-    functions_framework (0.5.1)
+    cloud_events (0.1.2)
+    functions_framework (0.7.0)
       cloud_events (~> 0.1)
       puma (~> 4.3)
       rack (~> 2.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.4)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
 
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 0.5)
+  functions_framework (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
This is a prerequisite for some of the additional functions samples, notably the slack sample.