### PR TITLE
fix(functions): Update scopes sample to use the on_startup construct

### DIFF
--- a/functions/test/concepts/scopes_test.rb
+++ b/functions/test/concepts/scopes_test.rb
@@ -22,7 +22,7 @@ describe "functions_concepts_scopes" do
       request = make_get_request "http://example.com:8080/"
       response = call_http "concepts_scopes", request
       assert_equal 200, response.status
-      assert_match(/function:/, response.body.join)
+      assert_equal "instance: heavy computation result; function: light computation result", response.body.join
     end
   end
 end


### PR DESCRIPTION
The original sample wasn't wrong, but was written before `on_startup` was added to the Ruby framework. This updates the sample to reflect the current best practice.