### PR TITLE
Update pubsub test service app.yaml and listener.rb

### DIFF
--- a/pubsub/app.yaml
+++ b/pubsub/app.yaml
@@ -13,5 +13,7 @@
 # limitations under the License.
 
 runtime: ruby
-vm: true
+env: flex
 entrypoint: bundle exec ruby listener.rb
+liveness_check:
+    path: "/liveness_check"

--- a/pubsub/listener.rb
+++ b/pubsub/listener.rb
@@ -23,4 +23,8 @@ post "/push" do
   response.status = 204
 end
 
+get "/liveness_check" do
+  response.status = 200
+end
+
 set :port, 8080


### PR DESCRIPTION
This PR fixes two deprecation warning/errors in the pubsub samples "push listener".