### PR TITLE
pubsub: delete duplicate sample for pubsub_publisher_batch_settings

### DIFF
--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -70,8 +70,7 @@ Usage:
     test_topic_permissions                          <project_id> <topic_name>                     Test topic permissions
     create_pull_subscription                        <project_id> <topic_name> <subscription_name> Create a pull subscription
     create_push_subscription                        <project_id> <topic_name> <subscription_name> Create a push subscription
-    publish_message                                 <project_id> <topic_name>                     Publish message 
-    publish_messages_with_batch_settings            <project_id> <topic_name>                     Publish messages in batch
+    publish_message                                 <project_id> <topic_name>                     Publish message
     publish_message_async                           <project_id> <topic_name>                     Publish messages asynchronously
     publish_messages_async_with_batch_settings      <project_id> <topic_name>                     Publish messages asynchronously in batch
     publish_message_async_with_custom_attributes    <project_id> <topic_name>                     Publish messages asynchronously with custom attributes

--- a/pubsub/spec/topics_spec.rb
+++ b/pubsub/spec/topics_spec.rb
@@ -193,30 +193,6 @@ describe "Pub/Sub topics sample" do
     end
   end
 
-  it "publishes messages with batch settings" do
-    topic = @pubsub.create_topic @topic_name
-    subscription = topic.subscribe @pull_subscription_name
-
-    expect {
-      publish_messages_with_batch_settings project_id: @project_id,
-                                           topic_name: @topic_name
-    }.to output(/Messages published in batch/).to_stdout
-
-    messages = []
-    expect_with_retry do
-      subscription.pull(max: 20).each do |message|
-        messages << message
-        message.acknowledge!
-      end
-      expect(messages.length).to eq(10)
-    end
-    received_time_counter = Hash.new 0
-    messages.each do |message|
-      received_time_counter[message.publish_time] += 1
-    end
-    expect(received_time_counter.length).to eq(1)
-  end
-
   it "publishes messages asynchronously" do
     topic = @pubsub.create_topic @topic_name
     subscription = topic.subscribe @pull_subscription_name

--- a/pubsub/topics.rb
+++ b/pubsub/topics.rb
@@ -193,25 +193,6 @@ def publish_message project_id:, topic_name:
   # [END pubsub_quickstart_publisher]
 end
 
-def publish_messages_with_batch_settings project_id:, topic_name:
-  # [START pubsub_publisher_batch_settings]
-  # project_id = "Your Google Cloud Project ID"
-  # topic_name = "Your Pubsub topic name"
-  require "google/cloud/pubsub"
-
-  pubsub = Google::Cloud::Pubsub.new project: project_id
-
-  topic = pubsub.topic topic_name
-  topic.publish do |batch|
-    10.times do |i|
-      batch.publish "This is message \##{i}."
-    end
-  end
-
-  puts "Messages published in batch."
-  # [END pubsub_publisher_batch_settings]
-end
-
 def publish_message_async project_id:, topic_name:
   # [START pubsub_publish]
   # project_id = "Your Google Cloud Project ID"
@@ -400,9 +381,6 @@ if $PROGRAM_NAME == __FILE__
   when "publish_message"
     publish_message project_id: ARGV.shift,
                     topic_name: ARGV.shift
-  when "publish_messages_with_batch_settings"
-    publish_messages_with_batch_settings project_id: ARGV.shift,
-                                         topic_name: ARGV.shift
   when "publish_message_async"
     publish_message_async project_id: ARGV.shift,
                           topic_name: ARGV.shift
@@ -410,8 +388,8 @@ if $PROGRAM_NAME == __FILE__
     publish_message_async_with_custom_attributes project_id: ARGV.shift,
                                                  topic_name: ARGV.shift
   when "publish_messages_async_with_batch_settings"
-    publish_messages_with_batch_settings project_id: ARGV.shift,
-                                         topic_name: ARGV.shift
+    publish_messages_async_with_batch_settings project_id: ARGV.shift,
+                                               topic_name: ARGV.shift
   when "publish_messages_async_with_concurrency_control"
     publish_messages_async_with_concurrency_control project_id: ARGV.shift,
                                                     topic_name: ARGV.shift
@@ -437,7 +415,6 @@ if $PROGRAM_NAME == __FILE__
         create_ordered_pull_subscription                <project_id> <topic_name> <subscription_name> Create a pull subscription with ordering enabled
         create_push_subscription                        <project_id> <topic_name> <subscription_name> Create a push subscription
         publish_message                                 <project_id> <topic_name>                     Publish message
-        publish_messages_with_batch_settings            <project_id> <topic_name>                     Publish messages in batch
         publish_message_async                           <project_id> <topic_name>                     Publish messages asynchronously
         publish_message_async_with_custom_attributes    <project_id> <topic_name>                     Publish messages asynchronously with custom attributes
         publish_messages_async_with_batch_settings      <project_id> <topic_name>                     Publish messages asynchronously in batch


### PR DESCRIPTION
I found duplicate samples for region tag `pubsub_publisher_batch_settings`

[topics.rb#L197](https://github.com/kamalaboulhosn/ruby-docs-samples/blob/f8e00ce0b6b68f764201603c3befd303820c9208/pubsub/topics.rb#L197) and [topics.rb#L257](https://github.com/kamalaboulhosn/ruby-docs-samples/blob/f8e00ce0b6b68f764201603c3befd303820c9208/pubsub/topics.rb#L257).

@anguillanneuf says:

>  The L257 one is the correct sample and is being used by https://cloud.google.com/pubsub/docs/publisher#batching.