### PR TITLE
fix(functions): Fix event function terminology and use context-provided logger

### DIFF
--- a/functions/Gemfile.lock
+++ b/functions/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       puma (~> 4.3)
       rack (~> 2.1)
     gli (2.19.2)
-    google-api-client (0.45.1)
+    google-api-client (0.46.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 0.9)
       httpclient (>= 2.8.1, < 3.0)
@@ -24,7 +24,7 @@ GEM
       retriable (>= 2.0, < 4.0)
       rexml
       signet (~> 0.12)
-    googleauth (0.13.1)
+    googleauth (0.14.0)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)

--- a/functions/firebase/firestore/app.rb
+++ b/functions/firebase/firestore/app.rb
@@ -21,8 +21,8 @@ FunctionsFramework.cloud_event "hello_firestore" do |event|
   # See https://cloudevents.github.io/sdk-ruby/latest/CloudEvents/Event/V1.html
   payload = event.data
 
-  FunctionsFramework.logger.info "Function triggered by change to: #{event.source}"
-  FunctionsFramework.logger.info "Old value: #{payload['oldValue']}"
-  FunctionsFramework.logger.info "New value: #{payload['value']}"
+  logger.info "Function triggered by change to: #{event.source}"
+  logger.info "Old value: #{payload['oldValue']}"
+  logger.info "New value: #{payload['value']}"
 end
 # [END functions_firebase_firestore]

--- a/functions/helloworld/pubsub/app.rb
+++ b/functions/helloworld/pubsub/app.rb
@@ -20,8 +20,9 @@ FunctionsFramework.cloud_event "hello_pubsub" do |event|
   # The event parameter is a CloudEvents::Event::V1 object.
   # See https://cloudevents.github.io/sdk-ruby/latest/CloudEvents/Event/V1.html
   name = Base64.decode64 event.data["message"]["data"] rescue "World"
-  # A background function does not return a response, but you can log messages
+
+  # A cloud_event function does not return a response, but you can log messages
   # or cause side effects such as sending additional events.
-  FunctionsFramework.logger.info "Hello, #{name}!"
+  logger.info "Hello, #{name}!"
 end
 # [END functions_helloworld_pubsub]

--- a/functions/helloworld/storage/app.rb
+++ b/functions/helloworld/storage/app.rb
@@ -20,12 +20,12 @@ FunctionsFramework.cloud_event "hello_gcs" do |event|
   # See https://cloudevents.github.io/sdk-ruby/latest/CloudEvents/Event/V1.html
   payload = event.data
 
-  FunctionsFramework.logger.info "Event: #{event.id}"
-  FunctionsFramework.logger.info "Event Type: #{event.type}"
-  FunctionsFramework.logger.info "Bucket: #{payload['bucket']}"
-  FunctionsFramework.logger.info "File: #{payload['name']}"
-  FunctionsFramework.logger.info "Metageneration: #{payload['metageneration']}"
-  FunctionsFramework.logger.info "Created: #{payload['timeCreated']}"
-  FunctionsFramework.logger.info "Updated: #{payload['updated']}"
+  logger.info "Event: #{event.id}"
+  logger.info "Event Type: #{event.type}"
+  logger.info "Bucket: #{payload['bucket']}"
+  logger.info "File: #{payload['name']}"
+  logger.info "Metageneration: #{payload['metageneration']}"
+  logger.info "Created: #{payload['timeCreated']}"
+  logger.info "Updated: #{payload['updated']}"
 end
 # [END functions_helloworld_storage]

--- a/functions/tips/infinite_retries/app.rb
+++ b/functions/tips/infinite_retries/app.rb
@@ -23,11 +23,11 @@ FunctionsFramework.cloud_event "avoid_infinite_retries" do |event|
   max_age_ms = 10_000
   if event_age_ms > max_age_ms
     # Ignore events that are too old.
-    FunctionsFramework.logger.info "Dropped #{event.id} (age #{event_age_ms}ms)"
+    logger.info "Dropped #{event.id} (age #{event_age_ms}ms)"
 
   else
     # Do what the function is supposed to do.
-    FunctionsFramework.logger.info "Handling #{event.id} (age #{event_age_ms}ms)..."
+    logger.info "Handling #{event.id} (age #{event_age_ms}ms)..."
     failed = true
 
     # Raise an exception to signal failure and trigger a retry.

--- a/functions/tips/retry/app.rb
+++ b/functions/tips/retry/app.rb
@@ -22,14 +22,14 @@ FunctionsFramework.cloud_event "retry_or_not" do |event|
     # Simulate a failure
     raise "I failed!"
   rescue RuntimeError => e
-    FunctionsFramework.logger.warn "Caught an error: #{e}"
+    logger.warn "Caught an error: #{e}"
     if try_again
       # Raise an exception to return a 500 and trigger a retry.
-      FunctionsFramework.logger.info "Trying again..."
+      logger.info "Trying again..."
       raise ex
     else
       # Return normally to end processing of this event.
-      FunctionsFramework.logger.info "Giving up."
+      logger.info "Giving up."
     end
   end
 end


### PR DESCRIPTION
1. The pubsub helloworld sample will appear in the cloudsite page that discusses "CloudEvent functions", but the sample includes a comment that still refers to itself as a "background function". Fixed.
2. A bunch of older samples use `FunctionsFramework.logger` to reference the global framework logger. In newer versions of the Ruby FF, the best practice is to use `logger` to reference the context-provided logger. Changed those samples.