### PR TITLE
pubsub: Add DLQ, detach, error and lease samples

### DIFF
--- a/pubsub/Gemfile.lock
+++ b/pubsub/Gemfile.lock
@@ -5,8 +5,9 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
     concurrent-ruby (1.1.7)
-    faraday (1.0.1)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     gapic-common (0.3.4)
       google-protobuf (~> 3.12, >= 3.12.2)
       googleapis-common-protos (>= 1.3.9, < 2.0)

--- a/pubsub/acceptance/subscriptions_test.rb
+++ b/pubsub/acceptance/subscriptions_test.rb
@@ -108,12 +108,11 @@ describe "subscriptions" do
     end
   end
 
-  it "supports pubsub_subscriber_sync_pull_custom_attributes, pubsub_subscriber_async_pull_custom_attributes" do
+  it "supports pubsub_subscriber_async_pull_custom_attributes" do
     @topic.publish "This is a test message.", origin: "ruby-sample"
 
-    # pubsub_subscriber_sync_pull_custom_attributes
     # pubsub_subscriber_async_pull_custom_attributes
-    expect_with_retry "pubsub_spubsub_subscriber_sync_pull_custom_attributesubscriber_sync_pull" do
+    expect_with_retry "pubsub_subscriber_async_pull_custom_attributes" do
       out, _err = capture_io do
         listen_for_messages_with_custom_attributes subscription_name: subscription_name
       end

--- a/pubsub/acceptance/subscriptions_test.rb
+++ b/pubsub/acceptance/subscriptions_test.rb
@@ -38,7 +38,8 @@ describe "subscriptions" do
     @subscription.delete if @subscription
   end
 
-  it "supports pubsub_update_push_configuration, pubsub_list_subscriptions, pubsub_set_subscription_policy, pubsub_get_subscription_policy, pubsub_test_subscription_permissions, pubsub_delete_subscription" do
+  it "supports pubsub_update_push_configuration, pubsub_list_subscriptions, pubsub_set_subscription_policy, pubsub_get_subscription_policy, " \
+     "pubsub_test_subscription_permissions, pubsub_detach_subscription, pubsub_delete_subscription" do
     # pubsub_update_push_configuration
     assert_output "Push endpoint updated.\n" do
       update_push_configuration subscription_name: subscription_name, new_endpoint: endpoint
@@ -69,6 +70,11 @@ describe "subscriptions" do
     # pubsub_test_subscription_permissions
     assert_output "Permission to consume\nPermission to update\n" do
       test_subscription_permissions subscription_name: subscription_name
+    end
+
+    # pubsub_detach_subscription
+    assert_output "Subscription is detached.\n" do
+      detach_subscription subscription_name: subscription_name
     end
 
     # pubsub_delete_subscription

--- a/pubsub/acceptance/subscriptions_test.rb
+++ b/pubsub/acceptance/subscriptions_test.rb
@@ -144,6 +144,21 @@ describe "subscriptions" do
     end
   end
 
+  it "supports pubsub_subscriber_sync_pull_with_lease" do
+    @topic.publish "This is a test message."
+    sleep 1
+
+    # # pubsub_subscriber_sync_pull_with_lease
+    expect_with_retry "pubsub_subscriber_sync_pull_with_lease" do
+      out, _err = capture_io do
+        subscriber_sync_pull_with_lease subscription_name: subscription_name
+      end
+      assert_includes out, "Reset ack deadline for \"This is a test message.\" for 30 seconds."
+      assert_includes out, "Finished processing \"This is a test message.\"."
+      assert_includes out, "Done."
+    end
+  end
+
   # Pub/Sub calls may not respond immediately.
   # Wrap expectations that may require multiple attempts with this method.
   def expect_with_retry sample_name, attempts: 2

--- a/pubsub/acceptance/topics_test.rb
+++ b/pubsub/acceptance/topics_test.rb
@@ -177,43 +177,45 @@ describe "topics" do
     #setup
     @topic = pubsub.create_topic topic_name
     @dead_letter_topic = pubsub.create_topic dead_letter_topic_name
+    
+    begin
+      # pubsub_dead_letter_create_subscription
+      out, _err = capture_io do
+        dead_letter_create_subscription topic_name: topic_name,
+                                        subscription_name: subscription_name,
+                                        dead_letter_topic_name: dead_letter_topic_name
+      end
+      assert_includes out, "Created subscription #{subscription_name} with dead letter topic #{dead_letter_topic_name}."
 
-    # pubsub_dead_letter_create_subscription
-    out, _err = capture_io do
-      dead_letter_create_subscription topic_name: topic_name,
-                                      subscription_name: subscription_name,
-                                      dead_letter_topic_name: dead_letter_topic_name
+      @subscription = @topic.subscription subscription_name
+      assert @subscription
+      assert_equal "projects/#{pubsub.project}/subscriptions/#{subscription_name}", @subscription.name
+      assert @subscription.dead_letter_topic
+      assert_equal "projects/#{pubsub.project}/topics/#{dead_letter_topic_name}", @subscription.dead_letter_topic.name
+      assert_equal 10, @subscription.dead_letter_max_delivery_attempts
+
+      # pubsub_dead_letter_update_subscription
+      assert_output "Max delivery attempts is now 20.\n" do
+        dead_letter_update_subscription subscription_name: subscription_name
+      end
+      @subscription.reload!
+      assert @subscription.dead_letter_topic
+      assert_equal "projects/#{pubsub.project}/topics/#{dead_letter_topic_name}", @subscription.dead_letter_topic.name
+      assert_equal 20, @subscription.dead_letter_max_delivery_attempts
+
+      @topic.publish "This is a dead letter topic test message."
+      # pubsub_dead_letter_delivery_attempt
+      expect_with_retry "pubsub_dead_letter_delivery_attempt" do
+        out, _err = capture_io do
+          dead_letter_delivery_attempt subscription_name: subscription_name
+        end
+        assert_includes out, "Received message: This is a dead letter topic test message."
+        assert_includes out, "Delivery Attempt: 1"
+      end
+
+    ensure
+      @dead_letter_topic.delete
     end
-    assert_includes out, "Created subscription #{subscription_name} with dead letter topic #{dead_letter_topic_name}."
-
-    @subscription = @topic.subscription subscription_name
-    assert @subscription
-    assert_equal "projects/#{pubsub.project}/subscriptions/#{subscription_name}", @subscription.name
-    assert @subscription.dead_letter_topic
-    assert_equal "projects/#{pubsub.project}/topics/#{dead_letter_topic_name}", @subscription.dead_letter_topic.name
-    assert_equal 10, @subscription.dead_letter_max_delivery_attempts
-
-    # pubsub_dead_letter_update_subscription
-    assert_output "Max delivery attempts is now 20.\n" do
-      dead_letter_update_subscription subscription_name: subscription_name
-    end
-    @subscription.reload!
-    assert @subscription.dead_letter_topic
-    assert_equal "projects/#{pubsub.project}/topics/#{dead_letter_topic_name}", @subscription.dead_letter_topic.name
-    assert_equal 20, @subscription.dead_letter_max_delivery_attempts
-
-    @topic.publish "This is a dead letter topic test message."
-    # pubsub_dead_letter_delivery_attempt
-    expect_with_retry "pubsub_dead_letter_delivery_attempt" do
-       out, _err = capture_io do
-         dead_letter_delivery_attempt subscription_name: subscription_name
-       end
-       assert_includes out, "Received message: This is a dead letter topic test message."
-       assert_includes out, "Delivery Attempt: 1"
-    end
-
-  ensure
-    @dead_letter_topic.delete if @dead_letter_topic
   end
 
   it "supports pubsub_publish" do

--- a/pubsub/acceptance/topics_test.rb
+++ b/pubsub/acceptance/topics_test.rb
@@ -309,6 +309,27 @@ describe "topics" do
     end
   end
 
+  it "supports publish_with_error_handler" do
+    #setup
+    @topic = pubsub.create_topic topic_name
+    @subscription = @topic.subscribe random_subscription_name
+
+    # publish_with_error_handler
+    assert_output "Message published asynchronously.\n" do
+      publish_message_async topic_name: topic_name
+    end
+
+    messages = []
+    expect_with_retry "pubsub_publish" do
+      @subscription.pull(max: 1).each do |message|
+        messages << message
+        message.acknowledge!
+      end
+      assert_equal 1, messages.length
+      assert_equal "This is a test message.", messages[0].data
+    end
+  end
+
   # Pub/Sub calls may not respond immediately.
   # Wrap expectations that may require multiple attempts with this method.
   def expect_with_retry sample_name, attempts: 5

--- a/pubsub/subscriptions.rb
+++ b/pubsub/subscriptions.rb
@@ -44,6 +44,26 @@ def list_subscriptions
   # [END pubsub_list_subscriptions]
 end
 
+def detach_subscription subscription_name:
+  # [START pubsub_detach_subscription]
+  # subscription_name = "Your Pubsub subscription name"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_name
+  subscription.detach
+
+  sleep 120
+  subscription.reload!
+  if subscription.detached?
+    puts "Subscription is detached."
+  else
+    puts "Subscription is NOT detached."
+  end
+  # [END pubsub_detach_subscription]
+end
+
 def delete_subscription subscription_name:
   # [START pubsub_delete_subscription]
   # subscription_name = "Your Pubsub subscription name"
@@ -53,6 +73,8 @@ def delete_subscription subscription_name:
 
   subscription = pubsub.subscription subscription_name
   subscription.delete
+
+
 
   puts "Subscription #{subscription_name} deleted."
   # [END pubsub_delete_subscription]

--- a/pubsub/subscriptions.rb
+++ b/pubsub/subscriptions.rb
@@ -307,6 +307,8 @@ if $PROGRAM_NAME == __FILE__
                               new_endpoint:      ARGV.shift
   when "list_subscriptions"
     list_subscriptions
+  when "detach_subscription"
+    detach_subscription subscription_name: ARGV.shift
   when "delete_subscription"
     delete_subscription subscription_name: ARGV.shift
   when "get_subscription_policy"
@@ -315,6 +317,8 @@ if $PROGRAM_NAME == __FILE__
     set_subscription_policy subscription_name: ARGV.shift
   when "test_subscription_permissions"
     test_subscription_permissions subscription_name: ARGV.shift
+  when "dead_letter_update_subscription"
+    dead_letter_update_subscription subscription_name: ARGV.shift
   when "listen_for_messages"
     listen_for_messages subscription_name: ARGV.shift
   when "listen_for_messages_with_custom_attributes"
@@ -327,6 +331,8 @@ if $PROGRAM_NAME == __FILE__
     listen_for_messages_with_flow_control subscription_name: ARGV.shift
   when "listen_for_messages_with_concurrency_control"
     listen_for_messages_with_concurrency_control subscription_name: ARGV.shift
+  when "dead_letter_delivery_attempt"
+    dead_letter_delivery_attempt subscription_name: ARGV.shift
   else
     puts <<~USAGE
       Usage: bundle exec ruby subscriptions.rb [command] [arguments]
@@ -334,16 +340,19 @@ if $PROGRAM_NAME == __FILE__
       Commands:
         update_push_configuration                    <subscription_name> <endpoint> Update the endpoint of a push subscription
         list_subscriptions                                                          List subscriptions of a project
+        detach_subscription                          <subscription_name>            Detach a subscription
         delete_subscription                          <subscription_name>            Delete a subscription
         get_subscription_policy                      <subscription_name>            Get policies of a subscription
         set_subscription_policy                      <subscription_name>            Set policies of a subscription
-        test_subscription_policy                     <subscription_name>            Test policies of a subscription
+        test_subscription_permissions                <subscription_name>            Test policies of a subscription
+        dead_letter_update_subscription              <subscription_name>            Update a subscription's dead letter policy
         listen_for_messages                          <subscription_name>            Listen for messages
         listen_for_messages_with_custom_attributes   <subscription_name>            Listen for messages with custom attributes
         pull_messages                                <subscription_name>            Pull messages
         listen_for_messages_with_error_handler       <subscription_name>            Listen for messages with an error handler
         listen_for_messages_with_flow_control        <subscription_name>            Listen for messages with flow control
         listen_for_messages_with_concurrency_control <subscription_name>            Listen for messages with concurrency control
+        dead_letter_delivery_attempt                 <subscription_name>            Pull messages that have a delivery attempts field
     USAGE
   end
 end

--- a/pubsub/subscriptions.rb
+++ b/pubsub/subscriptions.rb
@@ -166,7 +166,6 @@ def listen_for_messages subscription_name:
 end
 
 def listen_for_messages_with_custom_attributes subscription_name:
-  # [START pubsub_subscriber_sync_pull_custom_attributes]
   # [START pubsub_subscriber_async_pull_custom_attributes]
   # subscription_name = "Your Pubsub subscription name"
   require "google/cloud/pubsub"
@@ -191,7 +190,6 @@ def listen_for_messages_with_custom_attributes subscription_name:
   sleep 60
   subscriber.stop.wait!
   # [END pubsub_subscriber_async_pull_custom_attributes]
-  # [END pubsub_subscriber_sync_pull_custom_attributes]
 end
 
 def pull_messages subscription_name:

--- a/pubsub/subscriptions.rb
+++ b/pubsub/subscriptions.rb
@@ -105,6 +105,21 @@ def test_subscription_permissions subscription_name:
   # [END pubsub_test_subscription_permissions]
 end
 
+def dead_letter_update_subscription subscription_name:
+  # [START pubsub_dead_letter_update_subscription]
+  # subscription_name = "Your Pubsub subscription name"
+  # role = "roles/pubsub.publisher"
+  # service_account_email = "serviceAccount:account_name@project_name.iam.gserviceaccount.com"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_name
+  subscription.dead_letter_max_delivery_attempts = 20
+  puts "Max delivery attempts is now #{subscription.dead_letter_max_delivery_attempts}."
+  # [END pubsub_dead_letter_update_subscription]
+end
+
 def listen_for_messages subscription_name:
   # [START pubsub_subscriber_async_pull]
   # [START pubsub_quickstart_subscriber]
@@ -247,6 +262,22 @@ def listen_for_messages_with_concurrency_control subscription_name:
   sleep 60
   subscriber.stop.wait!
   # [END pubsub_subscriber_concurrency_control]
+end
+
+def dead_letter_delivery_attempt subscription_name:
+  # [START pubsub_dead_letter_delivery_attempt]
+  # subscription_name = "Your Pubsub subscription name"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_name
+  subscription.pull.each do |message|
+    puts "Received message: #{message.data}"
+    puts "Delivery Attempt: #{message.delivery_attempt}"
+    message.acknowledge!
+  end
+  # [END pubsub_dead_letter_delivery_attempt]
 end
 
 if $PROGRAM_NAME == __FILE__

--- a/pubsub/topics.rb
+++ b/pubsub/topics.rb
@@ -397,6 +397,10 @@ if $PROGRAM_NAME == __FILE__
     create_push_subscription topic_name:        ARGV.shift,
                              subscription_name: ARGV.shift,
                              endpoint:          ARGV.shift
+  when "dead_letter_create_subscription"
+    dead_letter_create_subscription topic_name:             ARGV.shift,
+                                    subscription_name:      ARGV.shift,
+                                    dead_letter_topic_name: ARGV.shift
   when "publish_message"
     publish_message topic_name: ARGV.shift
   when "publish_message_async"
@@ -428,6 +432,7 @@ if $PROGRAM_NAME == __FILE__
         create_pull_subscription                        <topic_name> <subscription_name> Create a pull subscription
         create_ordered_pull_subscription                <topic_name> <subscription_name> Create a pull subscription with ordering enabled
         create_push_subscription                        <topic_name> <subscription_name> <endpoint> Create a push subscription
+        dead_letter_create_subscription                 <topic_name> <subscription_name> <dead_letter_topic_name> Create a subscription with a dead letter topic
         publish_message                                 <topic_name>                     Publish message
         publish_message_async                           <topic_name>                     Publish messages asynchronously
         publish_message_async_with_custom_attributes    <topic_name>                     Publish messages asynchronously with custom attributes

--- a/pubsub/topics.rb
+++ b/pubsub/topics.rb
@@ -407,6 +407,8 @@ if $PROGRAM_NAME == __FILE__
     publish_messages_with_batch_settings topic_name: ARGV.shift
   when "publish_messages_async_with_concurrency_control"
     publish_messages_async_with_concurrency_control topic_name: ARGV.shift
+  when "publish_with_error_handler"
+    publish_with_error_handler topic_name: ARGV.shift
   when "publish_ordered_messages"
     publish_ordered_messages topic_name: ARGV.shift
   when "publish_resume_publish"
@@ -431,6 +433,7 @@ if $PROGRAM_NAME == __FILE__
         publish_message_async_with_custom_attributes    <topic_name>                     Publish messages asynchronously with custom attributes
         publish_messages_async_with_batch_settings      <topic_name>                     Publish messages asynchronously in batch
         publish_messages_async_with_concurrency_control <topic_name>                     Publish messages asynchronously with concurrency control
+        publish_with_error_handler                      <topic_name>                     Publish messages asynchronously with error handling
         publish_ordered_messages                        <topic_name>                     Publish messages asynchronously with ordering keys
         publish_resume_publish                          <topic_name>                     Publish messages asynchronously with ordering keys and resume on failure
     USAGE

--- a/pubsub/topics.rb
+++ b/pubsub/topics.rb
@@ -169,6 +169,26 @@ def create_push_subscription topic_name:, subscription_name:, endpoint:
   # [END pubsub_create_push_subscription]
 end
 
+def dead_letter_create_subscription topic_name:, subscription_name:, dead_letter_topic_name:
+  # [START pubsub_dead_letter_create_subscription]
+  # topic_name             = "Your Pubsub topic name"
+  # subscription_name      = "Your Pubsub subscription name"
+  # dead_letter_topic_name = "Your Pubsub dead letter topic name"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic             = pubsub.topic topic_name
+  dead_letter_topic = pubsub.topic dead_letter_topic_name
+  subscription      = topic.subscribe subscription_name,
+                                      dead_letter_topic:                 dead_letter_topic,
+                                      dead_letter_max_delivery_attempts: 10
+
+  puts "Created subscription #{subscription_name} with dead letter topic #{dead_letter_topic_name}."
+  puts "To process dead letter messages, remember to add a subscription to your dead letter topic."
+  # [END pubsub_dead_letter_create_subscription]
+end
+
 def publish_message topic_name:
   # [START pubsub_quickstart_publisher]
   # topic_name = "Your Pubsub topic name"

--- a/pubsub/topics.rb
+++ b/pubsub/topics.rb
@@ -290,6 +290,29 @@ def publish_messages_async_with_concurrency_control topic_name:
   # [END pubsub_publisher_concurrency_control]
 end
 
+def publish_with_error_handler topic_name:
+  # [START pubsub_publish_with_error_handler]
+  # topic_name = "Your Pubsub topic name"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic = pubsub.topic topic_name
+
+  begin
+    topic.publish_async "This is a test message." do |result|
+      raise "Failed to publish the message." unless result.succeeded?
+      puts "Message published asynchronously."
+    end
+
+    # Stop the async_publisher to send all queued messages immediately.
+    topic.async_publisher.stop.wait!
+  rescue StandardError => e
+    puts "Received error while publishing: #{e.message}"
+  end
+  # [END pubsub_publish_with_error_handler]
+end
+
 def publish_ordered_messages topic_name:
   # [START pubsub_publish_with_ordering_keys]
   # topic_name = "Your Pubsub topic name"


### PR DESCRIPTION
* Add `pubsub_dead_letter_create_subscription`
* Add `pubsub_dead_letter_update_subscription`
* Add `pubsub_dead_letter_delivery_attempt`
* Add `pubsub_detach_subscription`
* Add `pubsub_publish_with_error_handler`
* Add `pubsub_subscriber_sync_pull_with_lease`
* Remove region tag (but not shared sample) `pubsub_subscriber_sync_pull_custom_attributes`


refs: #594
closes: #628
closes: #669