### PR TITLE
docs: add gh pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Description
+
+Fixes #<ISSUE-NUMBER>
+
+Note: It's a good idea to open an issue first for discussion.
+
+## Checklist
+- [ ] **Tests** pass
+- [ ] **Lint** pass: `bundle exec rubocop -a`
+- [ ] Please **merge** this PR for me once it is approved.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,5 @@ Note: It's a good idea to open an issue first for discussion.
 
 ## Checklist
 - [ ] **Tests** pass
-- [ ] **Lint** pass: `bundle exec rubocop -a`
+- [ ] **Lint** pass: `bundle exec rubocop`
 - [ ] Please **merge** this PR for me once it is approved.


### PR DESCRIPTION
Adds a basic minimal PR template with helpful commands for your PR. Feel free to suggest changes.

This lint command was in CONTRIBUTING, but it would be nice here.

Similar to python: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/PULL_REQUEST_TEMPLATE.md