### PR TITLE
pubsub(chore): Add sleep to expect_with_retry in tests

### DIFF
--- a/pubsub/acceptance/subscriptions_test.rb
+++ b/pubsub/acceptance/subscriptions_test.rb
@@ -161,13 +161,14 @@ describe "subscriptions" do
 
   # Pub/Sub calls may not respond immediately.
   # Wrap expectations that may require multiple attempts with this method.
-  def expect_with_retry sample_name, attempts: 2
+  def expect_with_retry sample_name, attempts: 5
     @attempt_number ||= 0
     yield
     @attempt_number = nil
   rescue Minitest::Assertion => e
     @attempt_number += 1
     puts "failed attempt #{@attempt_number} for #{sample_name}"
+    sleep @attempt_number*@attempt_number
     retry if @attempt_number < attempts
     @attempt_number = nil
     raise e

--- a/pubsub/acceptance/topics_test.rb
+++ b/pubsub/acceptance/topics_test.rb
@@ -339,6 +339,7 @@ describe "topics" do
   rescue Minitest::Assertion => e
     @attempt_number += 1
     puts "failed attempt #{@attempt_number} for #{sample_name}"
+    sleep @attempt_number*@attempt_number
     retry if @attempt_number < attempts
     @attempt_number = nil
     raise e


### PR DESCRIPTION
* Add sleep to expect_with_retry in tests
* Increase retries from 2 to 5 in subscriptions_test.rb.

closes: #696
closes: #697