### PR TITLE
Add error if env var is not set

### DIFF
--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -17,7 +17,7 @@
 
 # Use the official lightweight Ruby image.
 # https://hub.docker.com/_/ruby
-FROM ruby:2.7-slim
+FROM ruby:2.5-slim
 
 # Install production dependencies.
 WORKDIR /usr/src/app

--- a/run/helloworld/Gemfile.lock
+++ b/run/helloworld/Gemfile.lock
@@ -62,4 +62,4 @@ DEPENDENCIES
   sinatra (~> 2.0)
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/run/helloworld/README.md
+++ b/run/helloworld/README.md
@@ -31,8 +31,14 @@ docker run --rm -p 9090:8080 -e PORT=8080 helloworld:ruby
 
 ## Test
 
-```
+```sh
+# Set an environment variable with your GCP Project ID
+export GOOGLE_CLOUD_PROJECT=<PROJECT_ID>
+
+# Install dependencies
 bundle install
+
+# Run tests
 bundle exec rspec
 ```
 
@@ -46,8 +52,7 @@ export GOOGLE_CLOUD_PROJECT=<PROJECT_ID>
 gcloud builds submit --tag gcr.io/${GOOGLE_CLOUD_PROJECT}/helloworld
 
 # Deploy to Cloud Run
-gcloud run deploy helloworld \
---image gcr.io/${GOOGLE_CLOUD_PROJECT}/helloworld
+gcloud run deploy helloworld --image gcr.io/${GOOGLE_CLOUD_PROJECT}/helloworld
 ```
 
 Visit your deployed container by opening the service URL in a web browser.

--- a/run/helloworld/spec/e2e_spec.rb
+++ b/run/helloworld/spec/e2e_spec.rb
@@ -18,6 +18,9 @@ require "securerandom"
 
 describe "E2E tests" do
   before (:all) do
+    if !ENV["GOOGLE_CLOUD_PROJECT"]
+      raise "GOOGLE_CLOUD_PROJECT env var not found."
+    end
     suffix = SecureRandom.hex(15)
     system("gcloud",
       "builds",


### PR DESCRIPTION
## Description

Fixes #646

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [x] **Tests** pass
- [x] **Lint** pass: `bundle exec rubocop`
- [X] Please **merge** this PR for me once it is approved.
