### PR TITLE
samples(spanner): PITR samples backup fix

### DIFF
--- a/spanner/spanner_samples.rb
+++ b/spanner/spanner_samples.rb
@@ -1679,11 +1679,12 @@ def create_backup project_id:, instance_id:, database_id:, backup_id:
 
   require "google/cloud/spanner"
 
-  spanner  = Google::Cloud::Spanner.new project: project_id
+  spanner = Google::Cloud::Spanner.new project: project_id
+  client = spanner.client instance_id, database_id
   instance = spanner.instance instance_id
   database = instance.database database_id
   expire_time = Time.now + 14 * 24 * 3600 # 14 days from now
-  version_time = database.earliest_version_time
+  version_time = client.execute("SELECT CURRENT_TIMESTAMP() as timestamp").rows.first[:timestamp]
 
   job = database.create_backup backup_id, expire_time, version_time: version_time
 
@@ -1830,8 +1831,8 @@ def list_backups project_id:, instance_id:, backup_id:, database_id:
     puts backup.backup_id
   end
 
-  puts "All backups with a size greater than or equal to 0 bytes:"
-  instance.backups(filter: "size_bytes >= 0").all.each do |backup|
+  puts "All backups with a size greater than 500 bytes:"
+  instance.backups(filter: "size_bytes >= 500").all.each do |backup|
     puts backup.backup_id
   end
 

--- a/spanner/spec/spanner_samples_spec.rb
+++ b/spanner/spec/spanner_samples_spec.rb
@@ -1614,7 +1614,7 @@ describe "Google Cloud Spanner API samples" do
       "All backups that expire before a timestamp:\n#{backup.backup_id}"
     )
     expect(captured_output).to include(
-      "All backups with a size greater than or equal to 0 bytes:\n#{backup.backup_id}"
+      "All backups with a size greater than 500 bytes:\n#{backup.backup_id}"
     )
     expect(captured_output).to include(
       "All backups that were created after a timestamp that are also ready:\n#{backup.backup_id}"


### PR DESCRIPTION
Instead of using the earliest version time of the database, uses the current time (from spanner). If we used the earliest version time of the database instead we would be creating an empty backup, since the database we are backing up is not 1 hour old (default version retention period).