### PR TITLE
samples(spanner): parameterise create backup

### DIFF
--- a/spanner/spanner_samples.rb
+++ b/spanner/spanner_samples.rb
@@ -2065,14 +2065,6 @@ def run_sample arguments
                           database_id: database_id,
                           start_title: arguments.shift,
                           end_title:   arguments.shift
-  elsif commands.eql?("create_backup") && instance_id && database_id && arguments.size >= 2
-    require 'time'
-
-    create_backup project_id: project_id,
-                  instance_id: instance_id,
-                  database_id: database_id,
-                  backup_id: arguments.shift,
-                  version_time: Time.parse(arguments.shift)
   elsif commands.include?(command) && instance_id && database_id
     send command, project_id:  project_id,
                   instance_id: instance_id,

--- a/spanner/spanner_samples.rb
+++ b/spanner/spanner_samples.rb
@@ -1670,12 +1670,13 @@ def write_read_float64_array project_id:, instance_id:, database_id:
   # [END spanner_write_read_float64_array]
 end
 
-def create_backup project_id:, instance_id:, database_id:, backup_id:
+def create_backup project_id:, instance_id:, database_id:, backup_id:, version_time:
   # [START spanner_create_backup]
   # project_id  = "Your Google Cloud project ID"
   # instance_id = "Your Spanner instance ID"
   # database_id = "Your Spanner database ID"
   # backup_id = "Your Spanner backup ID"
+  # version_time = Time.now - 60 * 60 * 24 # 1 day ago
 
   require "google/cloud/spanner"
 
@@ -1684,7 +1685,6 @@ def create_backup project_id:, instance_id:, database_id:, backup_id:
   instance = spanner.instance instance_id
   database = instance.database database_id
   expire_time = Time.now + 14 * 24 * 3600 # 14 days from now
-  version_time = client.execute("SELECT CURRENT_TIMESTAMP() as timestamp").rows.first[:timestamp]
 
   job = database.create_backup backup_id, expire_time, version_time: version_time
 
@@ -2007,7 +2007,7 @@ def usage
       write_read_empty_float64_array     <instance_id> <database_id> Writes empty FLOAT64 array and read.
       write_read_null_float64_array      <instance_id> <database_id> Writes nil to FLOAT64 array and read.
       write_read_float64_array           <instance_id> <database_id> Writes FLOAT64 array and read.
-      create_backup                      <instance_id> <database_id> <backup_id> Create a backup.
+      create_backup                      <instance_id> <database_id> <backup_id> <version_time> Create a backup.
       restore_backup                     <instance_id> <database_id> <backup_id> Restore a database.
       create_backup_cancel               <instance_id> <database_id> <backup_id> Cancel a backup.
       list_backup_operations             <instance_id> List backup operations.
@@ -2065,6 +2065,14 @@ def run_sample arguments
                           database_id: database_id,
                           start_title: arguments.shift,
                           end_title:   arguments.shift
+  elsif commands.eql?("create_backup") && instance_id && database_id && arguments.size >= 2
+    require 'time'
+
+    create_backup project_id: project_id,
+                  instance_id: instance_id,
+                  database_id: database_id,
+                  backup_id: arguments.shift,
+                  version_time: Time.parse(arguments.shift)
   elsif commands.include?(command) && instance_id && database_id
     send command, project_id:  project_id,
                   instance_id: instance_id,

--- a/spanner/spec/spanner_samples_spec.rb
+++ b/spanner/spec/spanner_samples_spec.rb
@@ -1508,7 +1508,7 @@ describe "Google Cloud Spanner API samples" do
       create_backup project_id:   @project_id,
                     instance_id:  @instance.instance_id,
                     database_id:  database.database_id,
-                    backup_id:    @backup_id
+                    backup_id:    @backup_id,
                     version_time: version_time
     end
 

--- a/spanner/spec/spanner_samples_spec.rb
+++ b/spanner/spec/spanner_samples_spec.rb
@@ -1501,11 +1501,15 @@ describe "Google Cloud Spanner API samples" do
     cleanup_backup_resources
     database = create_database_with_data
 
+    client = @spanner.client @instance.instance_id, database.database_id
+    version_time = client.execute("SELECT CURRENT_TIMESTAMP() as timestamp").rows.first[:timestamp]
+
     capture do
-      create_backup project_id:  @project_id,
-                    instance_id: @instance.instance_id,
-                    database_id: database.database_id,
-                    backup_id:   @backup_id
+      create_backup project_id:   @project_id,
+                    instance_id:  @instance.instance_id,
+                    database_id:  database.database_id,
+                    backup_id:    @backup_id
+                    version_time: version_time
     end
 
     expect(captured_output).to include(

--- a/spanner/spec/spanner_samples_spec.rb
+++ b/spanner/spec/spanner_samples_spec.rb
@@ -90,11 +90,15 @@ describe "Google Cloud Spanner API samples" do
                       database_id: database.database_id
     end
 
+    client = @spanner.client @instance.instance_id, database.database_id
+    version_time = client.execute("SELECT CURRENT_TIMESTAMP() as timestamp").rows.first[:timestamp]
+
     capture do
-      create_backup project_id:  @project_id,
-                    instance_id: @instance.instance_id,
-                    database_id: database.database_id,
-                    backup_id:   @backup_id
+      create_backup project_id:   @project_id,
+                    instance_id:  @instance.instance_id,
+                    database_id:  database.database_id,
+                    backup_id:    @backup_id,
+                    version_time: version_time
 
       @test_backup = @instance.backup @backup_id
     end


### PR DESCRIPTION
Instead of hardcoding the version time in the create backup sample, parameterises it.