### PR TITLE
chore: give presubmit and system_tests their own common.cfg

### DIFF
--- a/.kokoro/presubmit/common.cfg
+++ b/.kokoro/presubmit/common.cfg
@@ -15,6 +15,12 @@ env_vars: {
     value: "github/ruby-docs-samples/.kokoro/system_tests.sh"
 }
 
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/ruby-2.5"
+}
+
 # Get the testing service account keys. They will be stored in
 # $KOKORO_KEYSTORE_DIR/71386_$KEYNAME.
 before_action {

--- a/.kokoro/presubmit/common.cfg
+++ b/.kokoro/presubmit/common.cfg
@@ -18,7 +18,7 @@ env_vars: {
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/ruby-2.5"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node"
 }
 
 # Get the testing service account keys. They will be stored in

--- a/.kokoro/presubmit/ruby-2.5.cfg
+++ b/.kokoro/presubmit/ruby-2.5.cfg
@@ -1,16 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/ruby-2.5"
-}
-
-env_vars: {
-    key: "RUN_ALL_TESTS"
-    value: "1"
-}
-
 env_vars: {
     key: "KOKORO_RUBY_VERSION"
     value: "2.5"

--- a/.kokoro/presubmit/ruby-2.6.cfg
+++ b/.kokoro/presubmit/ruby-2.6.cfg
@@ -1,11 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node"
-}
-
 env_vars: {
     key: "KOKORO_RUBY_VERSION"
     value: "2.6"

--- a/.kokoro/presubmit/ruby-2.7.cfg
+++ b/.kokoro/presubmit/ruby-2.7.cfg
@@ -1,11 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node"
-}
-
 env_vars: {
     key: "RUN_ALL_TESTS"
     value: "1"

--- a/.kokoro/presubmit/ruby-3.0.cfg
+++ b/.kokoro/presubmit/ruby-3.0.cfg
@@ -1,11 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node"
-}
-
 env_vars: {
     key: "KOKORO_RUBY_VERSION"
     value: "3.0"

--- a/.kokoro/system_tests/common.cfg
+++ b/.kokoro/system_tests/common.cfg
@@ -18,7 +18,7 @@ env_vars: {
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/ruby-2.5"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node"
 }
 
 # Get the testing service account keys. They will be stored in

--- a/.kokoro/system_tests/common.cfg
+++ b/.kokoro/system_tests/common.cfg
@@ -1,0 +1,76 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download trampoline resources. These will be in ${KOKORO_GFILE_DIR}
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# All builds use the trampoline script to run in docker.
+build_file: "ruby-docs-samples/.kokoro/trampoline.sh"
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/ruby-docs-samples"
+
+# Tell the trampoline which build file to use.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/ruby-docs-samples/.kokoro/system_tests.sh"
+}
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/ruby-2.5"
+}
+
+# Get the testing service account keys. They will be stored in
+# $KOKORO_KEYSTORE_DIR/71386_$KEYNAME.
+before_action {
+    fetch_keystore {
+        keystore_resource {
+            keystore_config_id: 71386
+            keyname: "kokoro-cloud-samples-ruby-test-0"
+        }
+        keystore_resource {
+            keystore_config_id: 71386
+            keyname: "kokoro-cloud-samples-ruby-test-1"
+        }
+        keystore_resource {
+            keystore_config_id: 71386
+            keyname: "kokoro-cloud-samples-ruby-test-2"
+        }
+        keystore_resource {
+            keystore_config_id: 71386
+            keyname: "kokoro-cloud-samples-ruby-test-3"
+        }
+        keystore_resource {
+            keystore_config_id: 71386
+            keyname: "kokoro-cloud-samples-ruby-test-4"
+        }
+        keystore_resource {
+            keystore_config_id: 71386
+            keyname: "kokoro-cloud-samples-ruby-test-5"
+        }
+        keystore_resource {
+            keystore_config_id: 71386
+            keyname: "kokoro-cloud-samples-ruby-test-6"
+        }
+        keystore_resource {
+            keystore_config_id: 71386
+            keyname: "kokoro-cloud-samples-ruby-test-7"
+        }
+        keystore_resource {
+            keystore_config_id: 71386
+            keyname: "kokoro-cloud-samples-ruby-test-8"
+        }
+        keystore_resource {
+            keystore_config_id: 71386
+            keyname: "kokoro-cloud-samples-ruby-test-9"
+        }
+    }
+}
+
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.log"
+    regex: "**/*sponge_log.xml"
+  }
+}

--- a/.kokoro/system_tests/ruby-2.6.cfg
+++ b/.kokoro/system_tests/ruby-2.6.cfg
@@ -1,11 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node"
-}
-
 env_vars: {
     key: "KOKORO_RUBY_VERSION"
     value: "2.6"

--- a/.kokoro/system_tests/ruby-2.7.cfg
+++ b/.kokoro/system_tests/ruby-2.7.cfg
@@ -1,11 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node"
-}
-
 env_vars: {
     key: "RUN_ALL_TESTS"
     value: "1"

--- a/.kokoro/system_tests/ruby-3.0.cfg
+++ b/.kokoro/system_tests/ruby-3.0.cfg
@@ -1,11 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node"
-}
-
 env_vars: {
     key: "KOKORO_RUBY_VERSION"
     value: "3.0"

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,6 @@ def run_tests type
     header "Installing bundle in #{dir}"
     sh "bundle update"
   end
-  
 
   each_lib do |dir|
     start_time = Time.now

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,7 @@ def run_tests type
     header "Installing bundle in #{dir}"
     sh "bundle update"
   end
+  
 
   each_lib do |dir|
     start_time = Time.now


### PR DESCRIPTION
presubmit and system_tests aren't inheriting common.cfg from .kokoro/, so create common.cfg's for each separately.