### PR TITLE
chore: use latest docker image

### DIFF
--- a/.kokoro/system_tests/ruby-2.5.cfg
+++ b/.kokoro/system_tests/ruby-2.5.cfg
@@ -1,16 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/ruby-2.5"
-}
-
-env_vars: {
-    key: "RUN_ALL_TESTS"
-    value: "1"
-}
-
 env_vars: {
     key: "KOKORO_RUBY_VERSION"
     value: "2.5"


### PR DESCRIPTION
Edits the 2.5 ruby system test config to use the common docker file. 