### PR TITLE
docs: use single use transaction for quickstart query

### DIFF
--- a/spanner/quickstart.rb
+++ b/spanner/quickstart.rb
@@ -32,11 +32,8 @@ database_id = "my-database"
 database_client = spanner.client instance_id, database_id
 
 # Execute a simple SQL statement
-database_client.transaction do |transaction|
-  results = transaction.execute "SELECT 1"
-
-  results.rows.each do |row|
-    puts row
-  end
+results = database_client.execute_query "SELECT 1"
+results.rows.each do |row|
+  puts row
 end
 # [END spanner_quickstart]


### PR DESCRIPTION
The quickstart simple query example should use a single-use read-only transaction, as that is the most efficient way to execute a single query. The current sample uses a read/write transaction, which is the least efficient way to execute a single query.
