### PR TITLE
chore(run): update rails cloud run app to work on Ruby 3.0.2 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,7 @@ def dirs
   entries.uniq!
   if RUBY_VERSION.start_with? "2.4"
     entries.delete_if { |dir| dir.include? "/ruby-docs-samples/functions" }
-  elsif !RUBY_VERSION.start_with? "2.7"
+  elsif !RUBY_VERSION.start_with? "3.0"
     entries.delete_if { |dir| dir.include? "/ruby-docs-samples/run/rails" }
   end
   entries

--- a/run/rails/Dockerfile
+++ b/run/rails/Dockerfile
@@ -1,6 +1,6 @@
 # Use the official Ruby image from Docker Hub
 # https://hub.docker.com/_/ruby
-FROM ruby:2.7
+FROM ruby:3.0
 
 RUN (curl -sL https://deb.nodesource.com/setup_14.x | bash -) && apt-get update && apt-get install -y nodejs 
 
@@ -28,4 +28,4 @@ ENV RAILS_MASTER_KEY=${MASTER_KEY}
 RUN bundle exec rake assets:precompile
 
 EXPOSE 8080
-CMD ["rails", "server", "-b", "0.0.0.0", "-p", "8080"]
+CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "8080"]

--- a/run/rails/Gemfile
+++ b/run/rails/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "~> 2.7.2"
+ruby ">= 2.7"
 gem "dotenv-rails", "~> 2.7", ">= 2.7.6"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 6.1.3", ">= 6.1.3.1"

--- a/run/rails/Gemfile.lock
+++ b/run/rails/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
-    faraday (1.5.0)
+    faraday (1.5.1)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -101,7 +101,7 @@ GEM
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
     faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.1.0)
+    faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     ffi (1.15.3)
     globalid (0.4.2)
@@ -125,7 +125,7 @@ GEM
     google-cloud-env (1.5.0)
       faraday (>= 0.17.3, < 2.0)
     google-cloud-errors (1.1.0)
-    google-cloud-storage (1.34.0)
+    google-cloud-storage (1.34.1)
       addressable (~> 2.5)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
@@ -158,14 +158,12 @@ GEM
     memoist (0.16.2)
     method_source (1.0.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.5.3)
     minitest (5.14.4)
     msgpack (1.4.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     nio4r (2.5.7)
-    nokogiri (1.11.7)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
     os (1.1.1)
     pg (1.2.3)
@@ -206,7 +204,7 @@ GEM
       method_source
       rake (>= 0.13)
       thor (~> 1.0)
-    rake (13.0.5)
+    rake (13.0.6)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -275,7 +273,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-20
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
@@ -299,7 +297,7 @@ DEPENDENCIES
   webpacker (~> 5.0)
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.17
+   2.2.22

--- a/run/rails/Gemfile.lock
+++ b/run/rails/Gemfile.lock
@@ -158,12 +158,14 @@ GEM
     memoist (0.16.2)
     method_source (1.0.0)
     mini_mime (1.1.0)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     msgpack (1.4.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     nio4r (2.5.7)
-    nokogiri (1.11.7-x86_64-darwin)
+    nokogiri (1.11.7)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     os (1.1.1)
     pg (1.2.3)
@@ -273,7 +275,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  x86_64-darwin-20
+  ruby
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
@@ -300,4 +302,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.22
+   2.2.23


### PR DESCRIPTION
Update Rails Cloud Run starter app to default to using Ruby 3.0.2 by changing the Dockerfile base image, Gemfile, and Gemfile.lock. Also, edit the entrypoint in Dockefile from "rails" to "bin/rails"

Fixes #825 and Fixes #826


