### PR TITLE
(minor) fix grid layout for elements on page

### DIFF
--- a/run/rails/app/views/photos/index.html.erb
+++ b/run/rails/app/views/photos/index.html.erb
@@ -1,12 +1,16 @@
 <br>
-<div class="row justify-content-center">
-  <%= link_to 'New Photo', new_photo_path, class:"btn btn-info show" %>
+<div class="container">
+    <div class="row justify-content-center">
+    <%= link_to 'New Photo', new_photo_path, class:"btn btn-info show" %>
+    </div>
 </div>
 <br>
 
 <% if @photos.empty? %>
-  <div class="row justify-content-center">
+  <div class="container">
+    <div class="row justify-content-center">
     <p>Album is empty. Click on "New Photo" to add a photo.</p>
+    </div>
   </div>
 <% else %>
   <div class="grid-container">


### PR DESCRIPTION
## Description

If row elements aren't wrapped in containers, they can cause issues in the flexgrid and cause the content to run off the page. 

[sample screenshot of issue](https://user-images.githubusercontent.com/813732/128974906-7618bcd6-e39e-4a43-b1f4-b72489a104d2.png) (note lower right scroll)


## Checklist
- [x] **Tests** pass
- [x] **Lint** pass: `bundle exec rubocop`
- [x] Please **merge** this PR for me once it is approved.
