### PR TITLE
Fix deprecated logging agent install script.

### DIFF
--- a/getting-started/gce/startup-script.sh
+++ b/getting-started/gce/startup-script.sh
@@ -14,8 +14,8 @@
 
 # [START getting_started_gce_startup_script]
 # Install Stackdriver logging agent
-curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
-bash install-logging-agent.sh
+curl -sSO https://dl.google.com/cloudagents/add-logging-agent-repo.sh
+bash add-logging-agent-repo.sh --also-install
 
 # Install dependencies
 apt-get update && apt-get -y upgrade && apt-get install -y autoconf bison \


### PR DESCRIPTION
See https://cloud.google.com/logging/docs/agent/installation for the latest installation instructions.

## Checklist
- [X] Please **merge** this PR for me once it is approved.
