### PR TITLE
Send the correct audience argument to JWT.decode

### DIFF
--- a/getting-started/authenticating-users/app.rb
+++ b/getting-started/authenticating-users/app.rb
@@ -60,7 +60,7 @@ def validate_assertion assertion
   a_header = Base64.decode64 assertion.split(".")[0]
   key_id = JSON.parse(a_header)["kid"]
   cert = OpenSSL::PKey::EC.new settings.certificates[key_id]
-  info = JWT.decode assertion, cert, true, algorithm: "ES256", audience: settings.audience
+  info = JWT.decode assertion, cert, true, algorithm: "ES256", aud: settings.audience
   [info[0]["email"], info[0]["sub"]]
 rescue StandardError => e
   puts "Failed to validate assertion: #{e}"


### PR DESCRIPTION
## Description

According to the documentation it's supposed to be aud: https://www.rubydoc.info/github/jwt/ruby-jwt#audience-claim

## Checklist
- [x] **Tests** pass
- [x] **Lint** pass: `bundle exec rubocop`
- [x] Please **merge** this PR for me once it is approved.
