### PR TITLE
feat: update gae sample to use latest ruby ga version

### DIFF
--- a/appengine/standard-hello_world/Gemfile
+++ b/appengine/standard-hello_world/Gemfile
@@ -15,7 +15,7 @@
 # [START gae_standard_quickstart_dependencies]
 source "https://rubygems.org"
 
-gem "sinatra", "~> 2.0"
+gem "sinatra", "~> 2.2.0"
 # [END gae_standard_quickstart_dependencies]
 
 group :test do
@@ -23,3 +23,5 @@ group :test do
   gem "rspec"
   gem "rspec_junit_formatter"
 end
+
+gem "webrick", "~> 1.7"

--- a/appengine/standard-hello_world/Gemfile
+++ b/appengine/standard-hello_world/Gemfile
@@ -16,6 +16,7 @@
 source "https://rubygems.org"
 
 gem "sinatra", "~> 2.2.0"
+gem "webrick", "~> 1.7"
 # [END gae_standard_quickstart_dependencies]
 
 group :test do
@@ -24,4 +25,3 @@ group :test do
   gem "rspec_junit_formatter"
 end
 
-gem "webrick", "~> 1.7"

--- a/appengine/standard-hello_world/Gemfile
+++ b/appengine/standard-hello_world/Gemfile
@@ -24,4 +24,3 @@ group :test do
   gem "rspec"
   gem "rspec_junit_formatter"
 end
-

--- a/appengine/standard-hello_world/Gemfile.lock
+++ b/appengine/standard-hello_world/Gemfile.lock
@@ -2,9 +2,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
-    mustermann (1.0.3)
-    rack (2.0.7)
-    rack-protection (2.0.5)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    rack (2.2.3)
+    rack-protection (2.2.0)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -21,12 +22,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    sinatra (2.0.5)
+    rspec_junit_formatter (0.5.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    ruby2_keywords (0.0.5)
+    sinatra (2.2.0)
       mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.5)
+      rack (~> 2.2)
+      rack-protection (= 2.2.0)
       tilt (~> 2.0)
-    tilt (2.0.9)
+    tilt (2.0.10)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby
@@ -34,7 +39,9 @@ PLATFORMS
 DEPENDENCIES
   rack-test
   rspec
-  sinatra (~> 2.0)
+  rspec_junit_formatter
+  sinatra (~> 2.2.0)
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   1.17.3
+   2.3.8

--- a/appengine/standard-hello_world/app.yaml
+++ b/appengine/standard-hello_world/app.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # [START gae_standard_quickstart_yaml]
-runtime: ruby25
+runtime: ruby30
 entrypoint: bundle exec ruby app.rb
 instance_class: F2
 # [END gae_standard_quickstart_yaml]


### PR DESCRIPTION
## Description

Fixes part of https://github.com/GoogleCloudPlatform/ruby-docs-samples/issues/965

## Checklist
- [x] **Tests** pass
- [x] **Lint** pass: `bundle exec rubocop`
- [x] Please **merge** this PR for me once it is approved.
