### PR TITLE
docs: add Google Cloud Samples browser link to readme template

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ See our other [Google Cloud Platform github
 repos](https://github.com/GoogleCloudPlatform) for sample applications and
 scaffolding for other frameworks and use cases.
 
+## Google Cloud Samples
+
+To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples?l=ruby).
+
+
 ## Run Locally
 1. Clone this repo.
    ```


### PR DESCRIPTION
Adding a generic Google Code Sample link to the readme template.
This is for the benefit of the users, in navigating available Google Cloud code samples.

## Description

Fixes #<ISSUE-NUMBER>

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] **Tests** pass
- [ ] **Lint** pass: `bundle exec rubocop`
- [x] Please **merge** this PR for me once it is approved.
