### PR TITLE
fix: Add missing product region tags for Cloud CDN snippets

### DIFF
--- a/cdn/sign_url.rb
+++ b/cdn/sign_url.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # [START signed_url]
+# [START cloudcdn_sign_url]
 def signed_url url:, key_name:, key:, expiration:
   # url        = "URL of the endpoint served by Cloud CDN"
   # key_name   = "Name of the signing key added to the Google Cloud Storage bucket or service"
@@ -43,6 +44,7 @@ def signed_url url:, key_name:, key:, expiration:
   # Concatenate the URL and encoded signature
   signed_url = "#{url}&Signature=#{encoded_signature}"
 end
+# [END cloudcdn_sign_url]
 # [END signed_url]
 
 if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
Cloud CDN Snippets are missing product's specific region tags. In this PR, we are only adding region tags. No code changes. For more details, refer to [b/264905390](b/264905390).

## Description

Fixes #<ISSUE-NUMBER>

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] **Tests** pass
- [ ] **Lint** pass: `bundle exec rubocop`
- [x] Please **merge** this PR for me once it is approved.
