### PR TITLE
chore: cleanup un-wanted region tags

### DIFF
--- a/cdn/sign_url.rb
+++ b/cdn/sign_url.rb
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START signed_url]
 # [START cloudcdn_sign_url]
 def signed_url url:, key_name:, key:, expiration:
   # url        = "URL of the endpoint served by Cloud CDN"
@@ -45,7 +44,6 @@ def signed_url url:, key_name:, key:, expiration:
   signed_url = "#{url}&Signature=#{encoded_signature}"
 end
 # [END cloudcdn_sign_url]
-# [END signed_url]
 
 if $PROGRAM_NAME == __FILE__
   if ARGV.count == 4


### PR DESCRIPTION
Old region tags are replaced with product specific region tags. Please check b/272509882 for more details.

New Region tags were added using Pull Request: https://github.com/GoogleCloudPlatform/ruby-docs-samples/pull/1042/

## Description

Fixes #<ISSUE-NUMBER>

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] **Tests** pass
- [ ] **Lint** pass: `bundle exec rubocop`
- [x] Please **merge** this PR for me once it is approved.
