### PR TITLE
feat(functions): create new samples for typed function signature

### DIFF
--- a/functions/Gemfile.lock
+++ b/functions/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     faraday-net_http (3.0.2)
     faraday-retry (2.2.0)
       faraday (~> 2.0)
-    functions_framework (1.3.0)
+    functions_framework (1.4.1)
       cloud_events (>= 0.7.0, < 2.a)
       puma (>= 4.3.0, < 7.a)
       rack (>= 2.1, < 4.a)
@@ -128,7 +128,7 @@ GEM
     public_suffix (5.0.1)
     puma (6.3.0)
       nio4r (~> 2.0)
-    rack (3.0.7)
+    rack (3.0.8)
     rake (13.0.6)
     rbtree (0.4.6)
     representable (3.2.0)
@@ -157,7 +157,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  functions_framework (~> 1.0)
+  functions_framework (>= 1.4.1)
   google-apis-kgsearch_v1 (~> 0.2)
   google-cloud-bigquery (~> 1.42)
   google-cloud-firestore (~> 2.4)

--- a/functions/test/typed/googlechatbot_test.rb
+++ b/functions/test/typed/googlechatbot_test.rb
@@ -1,0 +1,71 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "functions_framework"
+require "functions_framework/testing"
+require "functions_framework/server"
+require "json"
+require "minitest/autorun"
+
+describe "function_googlechatbot" do
+  include FunctionsFramework::Testing
+
+  it "correctly responds to a chat event" do
+    load_temporary "typed/googlechatbot/app.rb" do
+      expected = {
+        cardsV2: [
+          {
+            cardId: "avatarCard",
+            card: {
+              name: "Avatar Card",
+              header: {
+                title: "Hello janedoe!"
+              },
+              sections: [
+                {
+                  widgets: [
+                    {
+                      textParagraph: {
+                        text: "Your avatar picture: "
+                      }
+                    },
+                    {
+                      image: {
+                        imageUrl: "example.com/avatar.png"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+
+      payload = {
+        message: {
+          sender: {
+            displayName: "janedoe",
+            avatarUrl: "example.com/avatar.png"
+          }
+        }
+      }
+
+      request = make_post_request "http://example.com:8080/", JSON.generate(payload)
+      response = call_typed "chat", request
+      assert_equal 200, response.status
+      assert_equal JSON.generate(expected), response.body.join
+    end
+  end
+end

--- a/functions/test/typed/greeting_test.rb
+++ b/functions/test/typed/greeting_test.rb
@@ -1,0 +1,41 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "functions_framework"
+require "functions_framework/testing"
+require "functions_framework/server"
+require "json"
+require "minitest/autorun"
+
+describe "function_greeting" do
+  include FunctionsFramework::Testing
+
+  it "correctly responds to greeting requests" do
+    load_temporary "typed/greeting/app.rb" do
+      expected = {
+        message: "Hello Jane Doe!"
+      }
+
+      payload = {
+        first_name: "Jane",
+        last_name: "Doe"
+      }
+
+      request = make_post_request "http://example.com:8080/", JSON.generate(payload)
+      response = call_typed "greeting", request
+      assert_equal 200, response.status
+      assert_equal JSON.generate(expected), response.body.join
+    end
+  end
+end

--- a/functions/typed/googlechatbot/Gemfile
+++ b/functions/typed/googlechatbot/Gemfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,17 +15,5 @@
 source "https://rubygems.org"
 
 gem "functions_framework", "~> 1.4", ">= 1.4.1"
-
-group "test" do
-  gem "google-apis-kgsearch_v1", "~> 0.2"
-  gem "google-cloud-bigquery", "~> 1.42"
-  gem "google-cloud-firestore", "~> 2.4"
-  gem "google-cloud-storage", "~> 1.30"
-  gem "google-cloud-vision", "~> 1.1"
-  gem "mini_magick", "~> 4.11"
-  gem "minitest", "~> 5.16"
-  gem "minitest-focus", "~> 1.1"
-  gem "minitest-junit", "~> 1.1"
-  gem "rake", ">= 12.0"
-  gem "slack-ruby-client", ">= 1.0", "< 3"
-end
+gem "google-apis-kgsearch_v1", "~> 0.2"
+gem "slack-ruby-client", ">= 1.0", "< 3"

--- a/functions/typed/googlechatbot/Gemfile.lock
+++ b/functions/typed/googlechatbot/Gemfile.lock
@@ -1,0 +1,84 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
+    cloud_events (0.7.0)
+    declarative (0.0.20)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-mashify (0.1.1)
+      faraday (~> 2.0)
+      hashie
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (3.0.2)
+    functions_framework (1.4.1)
+      cloud_events (>= 0.7.0, < 2.a)
+      puma (>= 4.3.0, < 7.a)
+      rack (>= 2.1, < 4.a)
+    gli (2.21.0)
+    google-apis-core (0.11.0)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.16.2, < 2.a)
+      httpclient (>= 2.8.1, < 3.a)
+      mini_mime (~> 1.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.a)
+      rexml
+      webrick
+    google-apis-kgsearch_v1 (0.13.0)
+      google-apis-core (>= 0.11.0, < 2.a)
+    googleauth (1.6.0)
+      faraday (>= 0.17.3, < 3.a)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (>= 0.16, < 2.a)
+    hashie (5.0.0)
+    httpclient (2.8.3)
+    jwt (2.7.1)
+    memoist (0.16.2)
+    mini_mime (1.1.2)
+    multi_json (1.15.0)
+    multipart-post (2.3.0)
+    nio4r (2.5.9)
+    os (1.1.4)
+    public_suffix (5.0.1)
+    puma (6.3.0)
+      nio4r (~> 2.0)
+    rack (3.0.8)
+    representable (3.2.0)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    rexml (3.2.5)
+    ruby2_keywords (0.0.5)
+    signet (0.17.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    slack-ruby-client (2.1.0)
+      faraday (>= 2.0)
+      faraday-mashify
+      faraday-multipart
+      gli
+      hashie
+    trailblazer-option (0.1.2)
+    uber (0.1.0)
+    webrick (1.8.1)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  functions_framework (>= 1.4.1)
+  google-apis-kgsearch_v1 (~> 0.2)
+  slack-ruby-client (>= 1.0, < 3)
+
+BUNDLED WITH
+   2.4.13

--- a/functions/typed/googlechatbot/app.rb
+++ b/functions/typed/googlechatbot/app.rb
@@ -1,0 +1,53 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START functions_typed_googlechatbot]
+require "functions_framework"
+
+FunctionsFramework.typed "chat" do |req|
+  display_name = req["message"]["sender"]["displayName"]
+  image_url = req["message"]["sender"]["avatarUrl"]
+
+  card_header = {
+    title: "Hello #{display_name}!"
+  }
+
+  avatar_widget = {
+    textParagraph: { text: "Your avatar picture: " }
+  }
+
+  avatar_image_widget = {
+    image: {
+      imageUrl: image_url
+    }
+  }
+
+  avatar_section = {
+    widgets: [avatar_widget, avatar_image_widget]
+  }
+
+  {
+    cardsV2: [
+      {
+        cardId: "avatarCard",
+        card: {
+          name: "Avatar Card",
+          header: card_header,
+          sections: [avatar_section]
+        }
+      }
+    ]
+  }
+end
+# [END functions_typed_googlechatbot]

--- a/functions/typed/greeting/Gemfile
+++ b/functions/typed/greeting/Gemfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,17 +15,5 @@
 source "https://rubygems.org"
 
 gem "functions_framework", "~> 1.4", ">= 1.4.1"
-
-group "test" do
-  gem "google-apis-kgsearch_v1", "~> 0.2"
-  gem "google-cloud-bigquery", "~> 1.42"
-  gem "google-cloud-firestore", "~> 2.4"
-  gem "google-cloud-storage", "~> 1.30"
-  gem "google-cloud-vision", "~> 1.1"
-  gem "mini_magick", "~> 4.11"
-  gem "minitest", "~> 5.16"
-  gem "minitest-focus", "~> 1.1"
-  gem "minitest-junit", "~> 1.1"
-  gem "rake", ">= 12.0"
-  gem "slack-ruby-client", ">= 1.0", "< 3"
-end
+gem "google-apis-kgsearch_v1", "~> 0.2"
+gem "slack-ruby-client", ">= 1.0", "< 3"

--- a/functions/typed/greeting/Gemfile.lock
+++ b/functions/typed/greeting/Gemfile.lock
@@ -1,0 +1,84 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
+    cloud_events (0.7.0)
+    declarative (0.0.20)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-mashify (0.1.1)
+      faraday (~> 2.0)
+      hashie
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (3.0.2)
+    functions_framework (1.4.1)
+      cloud_events (>= 0.7.0, < 2.a)
+      puma (>= 4.3.0, < 7.a)
+      rack (>= 2.1, < 4.a)
+    gli (2.21.0)
+    google-apis-core (0.11.0)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.16.2, < 2.a)
+      httpclient (>= 2.8.1, < 3.a)
+      mini_mime (~> 1.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.a)
+      rexml
+      webrick
+    google-apis-kgsearch_v1 (0.13.0)
+      google-apis-core (>= 0.11.0, < 2.a)
+    googleauth (1.6.0)
+      faraday (>= 0.17.3, < 3.a)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (>= 0.16, < 2.a)
+    hashie (5.0.0)
+    httpclient (2.8.3)
+    jwt (2.7.1)
+    memoist (0.16.2)
+    mini_mime (1.1.2)
+    multi_json (1.15.0)
+    multipart-post (2.3.0)
+    nio4r (2.5.9)
+    os (1.1.4)
+    public_suffix (5.0.1)
+    puma (6.3.0)
+      nio4r (~> 2.0)
+    rack (3.0.8)
+    representable (3.2.0)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    rexml (3.2.5)
+    ruby2_keywords (0.0.5)
+    signet (0.17.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    slack-ruby-client (2.1.0)
+      faraday (>= 2.0)
+      faraday-mashify
+      faraday-multipart
+      gli
+      hashie
+    trailblazer-option (0.1.2)
+    uber (0.1.0)
+    webrick (1.8.1)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  functions_framework (~> 1.4, >= 1.4.1)
+  google-apis-kgsearch_v1 (~> 0.2)
+  slack-ruby-client (>= 1.0, < 3)
+
+BUNDLED WITH
+   2.4.13

--- a/functions/typed/greeting/app.rb
+++ b/functions/typed/greeting/app.rb
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source "https://rubygems.org"
+# [START functions_typed_greeting]
+require "functions_framework"
 
-gem "functions_framework", "~> 1.4", ">= 1.4.1"
-
-group "test" do
-  gem "google-apis-kgsearch_v1", "~> 0.2"
-  gem "google-cloud-bigquery", "~> 1.42"
-  gem "google-cloud-firestore", "~> 2.4"
-  gem "google-cloud-storage", "~> 1.30"
-  gem "google-cloud-vision", "~> 1.1"
-  gem "mini_magick", "~> 4.11"
-  gem "minitest", "~> 5.16"
-  gem "minitest-focus", "~> 1.1"
-  gem "minitest-junit", "~> 1.1"
-  gem "rake", ">= 12.0"
-  gem "slack-ruby-client", ">= 1.0", "< 3"
+FunctionsFramework.typed "greeting" do |req|
+  {
+    message: "Hello #{req['first_name']} #{req['last_name']}!"
+  }
 end
+# [END functions_typed_greeting]


### PR DESCRIPTION
## Description

Creates new samples for GCF nodejs strongly typed function signature. Samples added are

 * greeting - a typed hello world (accepting JSON)
 * googlechatbot - a typed function that matches the functionality documented in https://developers.google.com/chat/quickstart/gcf-app

## Checklist
- [X] **Tests** pass
- [X] **Lint** pass: `bundle exec rubocop`
- [ ] Please **merge** this PR for me once it is approved.
