### PR TITLE
fix: Fix namespace clash for deployment of metadata_server

### DIFF
--- a/spec/e2e.rb
+++ b/spec/e2e.rb
@@ -107,9 +107,10 @@ class E2E
 
     def versionize name
       version_name = name.tr "^A-Za-z0-9", ""
-      name_length  = 11
+      name_length  = 10
 
-      version_name[-name_length, name_length] || version_name
+      random_char = ('a'..'z').to_a[rand(26)]
+      "#{version_name[-name_length, name_length]}#{random_char}" || version_name
     end
 
     def url


### PR DESCRIPTION
Fixes #889

The versionize method in `e2e.rb` converts both the `appengine/metadata_server` and `standard-metadata-server` to the same result (`adataserver`). So we're appending a random character to then end to fix the namespace collision.

This flaky issue might be hard to confirm, since it happens due to chance-timing of two deployments.