### PR TITLE
chore: Update Instructions to test appengine

### DIFF
--- a/appengine/README.md
+++ b/appengine/README.md
@@ -58,6 +58,8 @@ variables to run most tests in this directory:
   * `E2E`: Enable end-to-end testing.
   * `TEST_DIR`: This is the relative path of the directory you're testing (e.g. `appengine/analytics`).
   * `BUILD_ID`: A unique ID for deployments.
+  * `GOOGLE_APPLICATION_CREDENTIALS`: Path to credentials json file
+  *  `E2E_GOOGLE_CLOUD_PROJECT`: Project ID to deploy
 
 Then run:
 

--- a/appengine/README.md
+++ b/appengine/README.md
@@ -59,7 +59,7 @@ variables to run most tests in this directory:
   * `TEST_DIR`: This is the relative path of the directory you're testing (e.g. `appengine/analytics`).
   * `BUILD_ID`: A unique ID for deployments.
   * `GOOGLE_APPLICATION_CREDENTIALS`: Path to credentials json file
-  *  `E2E_GOOGLE_CLOUD_PROJECT`: Project ID to deploy
+  * `E2E_GOOGLE_CLOUD_PROJECT`: Project ID to deploy
 
 Then run:
 


### PR DESCRIPTION
The [deploy script](https://github.com/GoogleCloudPlatform/ruby-docs-samples/blob/deployment-clash-fix/spec/e2e.rb) uses the environment variables [`GOOGLE_APPLICATION_CREDENTIALS`](https://github.com/GoogleCloudPlatform/ruby-docs-samples/blob/deployment-clash-fix/spec/e2e.rb#L50) and [`E2E_GOOGLE_CLOUD_PROJECT`](https://github.com/GoogleCloudPlatform/ruby-docs-samples/blob/deployment-clash-fix/spec/e2e.rb#L55) variables, but they're not mentioned in the `appengine/README.md` instructions. This PR adds them.