### PR TITLE
chore: Don't use headless browser for tests that don't have UI interactions

### DIFF
--- a/appengine/flexible/metadata_server/Gemfile
+++ b/appengine/flexible/metadata_server/Gemfile
@@ -19,8 +19,8 @@ gem "webrick"
 ruby "~>3.2.1"
 group :test do
   gem "capybara"
+  gem "faraday"
   gem "poltergeist"
   gem "rspec"
   gem "rspec_junit_formatter"
-  gem "faraday"
 end

--- a/appengine/flexible/metadata_server/Gemfile
+++ b/appengine/flexible/metadata_server/Gemfile
@@ -22,4 +22,5 @@ group :test do
   gem "poltergeist"
   gem "rspec"
   gem "rspec_junit_formatter"
+  gem "faraday"
 end

--- a/appengine/flexible/metadata_server/Gemfile
+++ b/appengine/flexible/metadata_server/Gemfile
@@ -18,9 +18,7 @@ gem "sinatra"
 gem "webrick"
 ruby "~>3.2.1"
 group :test do
-  gem "capybara"
   gem "faraday"
-  gem "poltergeist"
   gem "rspec"
   gem "rspec_junit_formatter"
 end

--- a/appengine/flexible/metadata_server/Gemfile.lock
+++ b/appengine/flexible/metadata_server/Gemfile.lock
@@ -14,10 +14,18 @@ GEM
       xpath (~> 3.2)
     cliver (0.3.2)
     diff-lcs (1.5.0)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     matrix (0.4.2)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.2)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    nokogiri (1.14.3)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     poltergeist (1.18.1)
@@ -62,15 +70,20 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES
   capybara
+  faraday
   poltergeist
   rspec
   rspec_junit_formatter
   sinatra
   webrick
+
+RUBY VERSION
+   ruby 3.2.1p31
 
 BUNDLED WITH
    2.4.12

--- a/appengine/flexible/metadata_server/spec/metadata_server_spec.rb
+++ b/appengine/flexible/metadata_server/spec/metadata_server_spec.rb
@@ -24,7 +24,7 @@ describe "Metadata server on Google App Engine", type: :feature do
   end
 
   it "displays IP address read from metadata server" do
-    response = Faraday.get(@url)
+    response = Faraday.get @url
 
     expect(response.body).to match(
       /External IP: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/

--- a/appengine/flexible/metadata_server/spec/metadata_server_spec.rb
+++ b/appengine/flexible/metadata_server/spec/metadata_server_spec.rb
@@ -14,10 +14,7 @@
 
 require File.expand_path("../../../spec/e2e", __dir__)
 require "rspec"
-require "capybara/rspec"
-require "capybara/poltergeist"
-
-Capybara.default_driver = :poltergeist
+require 'faraday'
 
 describe "Metadata server on Google App Engine", type: :feature do
   before :all do
@@ -27,9 +24,9 @@ describe "Metadata server on Google App Engine", type: :feature do
   end
 
   it "displays IP address read from metadata server" do
-    visit @url
+    response = Faraday.get(@url)
 
-    expect(page.body).to match(
+    expect(response.body).to match(
       /External IP: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
     )
   end

--- a/appengine/flexible/metadata_server/spec/metadata_server_spec.rb
+++ b/appengine/flexible/metadata_server/spec/metadata_server_spec.rb
@@ -14,7 +14,7 @@
 
 require File.expand_path("../../../spec/e2e", __dir__)
 require "rspec"
-require 'faraday'
+require "faraday"
 
 describe "Metadata server on Google App Engine", type: :feature do
   before :all do

--- a/appengine/flexible/ruby31-and-earlier/metadata_server/Gemfile
+++ b/appengine/flexible/ruby31-and-earlier/metadata_server/Gemfile
@@ -17,9 +17,7 @@ source "https://rubygems.org"
 gem "sinatra"
 
 group :test do
-  gem "capybara"
   gem "faraday"
-  gem "poltergeist"
   gem "rspec"
   gem "rspec_junit_formatter"
 end

--- a/appengine/flexible/ruby31-and-earlier/metadata_server/Gemfile
+++ b/appengine/flexible/ruby31-and-earlier/metadata_server/Gemfile
@@ -18,8 +18,8 @@ gem "sinatra"
 
 group :test do
   gem "capybara"
+  gem "faraday"
   gem "poltergeist"
   gem "rspec"
   gem "rspec_junit_formatter"
-  gem "faraday"
 end

--- a/appengine/flexible/ruby31-and-earlier/metadata_server/Gemfile
+++ b/appengine/flexible/ruby31-and-earlier/metadata_server/Gemfile
@@ -21,4 +21,5 @@ group :test do
   gem "poltergeist"
   gem "rspec"
   gem "rspec_junit_formatter"
+  gem "faraday"
 end

--- a/appengine/flexible/ruby31-and-earlier/metadata_server/Gemfile.lock
+++ b/appengine/flexible/ruby31-and-earlier/metadata_server/Gemfile.lock
@@ -1,36 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
-    capybara (3.2.1)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      xpath (~> 3.1)
-    cliver (0.3.2)
     diff-lcs (1.3)
     faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    mini_mime (1.0.0)
-    mini_portile2 (2.3.0)
     mustermann (1.0.2)
-    nokogiri (1.8.3)
-      mini_portile2 (~> 2.3.0)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
-    public_suffix (3.0.2)
     rack (2.0.6)
     rack-protection (2.0.3)
       rack
-    rack-test (1.0.0)
-      rack (>= 1.0, < 3)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -53,19 +32,12 @@ GEM
       rack-protection (= 2.0.3)
       tilt (~> 2.0)
     tilt (2.0.8)
-    websocket-driver (0.7.0)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
-    xpath (3.1.0)
-      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  capybara
   faraday
-  poltergeist
   rspec
   rspec_junit_formatter
   sinatra

--- a/appengine/flexible/ruby31-and-earlier/metadata_server/Gemfile.lock
+++ b/appengine/flexible/ruby31-and-earlier/metadata_server/Gemfile.lock
@@ -12,6 +12,10 @@ GEM
       xpath (~> 3.1)
     cliver (0.3.2)
     diff-lcs (1.3)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     mustermann (1.0.2)
@@ -40,6 +44,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
+    rspec_junit_formatter (0.6.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    ruby2_keywords (0.0.5)
     sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -57,8 +64,10 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  faraday
   poltergeist
   rspec
+  rspec_junit_formatter
   sinatra
 
 BUNDLED WITH

--- a/appengine/flexible/ruby31-and-earlier/metadata_server/spec/metadata_server_spec.rb
+++ b/appengine/flexible/ruby31-and-earlier/metadata_server/spec/metadata_server_spec.rb
@@ -24,7 +24,7 @@ describe "Metadata server on Google App Engine", type: :feature do
   end
 
   it "displays IP address read from metadata server" do
-    response = Faraday.get(@url)
+    response = Faraday.get @url
 
     expect(response.body).to match(
       /External IP: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/

--- a/appengine/flexible/ruby31-and-earlier/metadata_server/spec/metadata_server_spec.rb
+++ b/appengine/flexible/ruby31-and-earlier/metadata_server/spec/metadata_server_spec.rb
@@ -14,10 +14,7 @@
 
 require File.expand_path("../../../spec/e2e", __dir__)
 require "rspec"
-require "capybara/rspec"
-require "capybara/poltergeist"
-
-Capybara.default_driver = :poltergeist
+require 'faraday'
 
 describe "Metadata server on Google App Engine", type: :feature do
   before :all do
@@ -27,9 +24,9 @@ describe "Metadata server on Google App Engine", type: :feature do
   end
 
   it "displays IP address read from metadata server" do
-    visit @url
+    response = Faraday.get(@url)
 
-    expect(page.body).to match(
+    expect(response.body).to match(
       /External IP: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
     )
   end

--- a/appengine/flexible/ruby31-and-earlier/metadata_server/spec/metadata_server_spec.rb
+++ b/appengine/flexible/ruby31-and-earlier/metadata_server/spec/metadata_server_spec.rb
@@ -14,7 +14,7 @@
 
 require File.expand_path("../../../spec/e2e", __dir__)
 require "rspec"
-require 'faraday'
+require "faraday"
 
 describe "Metadata server on Google App Engine", type: :feature do
   before :all do

--- a/appengine/metadata_server/Gemfile
+++ b/appengine/metadata_server/Gemfile
@@ -17,9 +17,7 @@ source "https://rubygems.org"
 gem "sinatra"
 
 group :test do
-  gem "capybara"
   gem "faraday"
-  gem "poltergeist"
   gem "rspec"
   gem "rspec_junit_formatter"
 end

--- a/appengine/metadata_server/Gemfile
+++ b/appengine/metadata_server/Gemfile
@@ -18,8 +18,8 @@ gem "sinatra"
 
 group :test do
   gem "capybara"
+  gem "faraday"
   gem "poltergeist"
   gem "rspec"
   gem "rspec_junit_formatter"
-  gem "faraday"
 end

--- a/appengine/metadata_server/Gemfile
+++ b/appengine/metadata_server/Gemfile
@@ -21,4 +21,5 @@ group :test do
   gem "poltergeist"
   gem "rspec"
   gem "rspec_junit_formatter"
+  gem "faraday"
 end

--- a/appengine/metadata_server/Gemfile.lock
+++ b/appengine/metadata_server/Gemfile.lock
@@ -1,43 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.4)
-      public_suffix (>= 2.0.2, < 6.0)
-    capybara (3.39.2)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
-    cliver (0.3.2)
     diff-lcs (1.5.0)
     faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    matrix (0.4.2)
-    mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
-    nokogiri (1.15.3)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
-    public_suffix (5.0.1)
-    racc (1.7.1)
     rack (2.2.7)
     rack-protection (3.0.6)
       rack
-    rack-test (2.1.0)
-      rack (>= 1.3)
-    regexp_parser (2.8.1)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -60,19 +33,12 @@ GEM
       rack-protection (= 3.0.6)
       tilt (~> 2.0)
     tilt (2.2.0)
-    websocket-driver (0.7.5)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  capybara
   faraday
-  poltergeist
   rspec
   rspec_junit_formatter
   sinatra

--- a/appengine/metadata_server/Gemfile.lock
+++ b/appengine/metadata_server/Gemfile.lock
@@ -14,6 +14,10 @@ GEM
       xpath (~> 3.2)
     cliver (0.3.2)
     diff-lcs (1.5.0)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     matrix (0.4.2)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
@@ -67,6 +71,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  faraday
   poltergeist
   rspec
   rspec_junit_formatter

--- a/appengine/metadata_server/spec/metadata_server_spec.rb
+++ b/appengine/metadata_server/spec/metadata_server_spec.rb
@@ -24,7 +24,7 @@ describe "Metadata server on Google App Engine", type: :feature do
   end
 
   it "displays IP address read from metadata server" do
-    response = Faraday.get(@url)
+    response = Faraday.get @url
 
     expect(response.body).to match(
       /External IP: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/

--- a/appengine/metadata_server/spec/metadata_server_spec.rb
+++ b/appengine/metadata_server/spec/metadata_server_spec.rb
@@ -14,10 +14,7 @@
 
 require File.expand_path("../../../spec/e2e", __dir__)
 require "rspec"
-require "capybara/rspec"
-require "capybara/poltergeist"
-
-Capybara.default_driver = :poltergeist
+require "faraday"
 
 describe "Metadata server on Google App Engine", type: :feature do
   before :all do
@@ -27,9 +24,9 @@ describe "Metadata server on Google App Engine", type: :feature do
   end
 
   it "displays IP address read from metadata server" do
-    visit @url
+    response = Faraday.get(@url)
 
-    expect(page.body).to match(
+    expect(response.body).to match(
       /External IP: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
     )
   end

--- a/appengine/standard-metadata-server/Gemfile
+++ b/appengine/standard-metadata-server/Gemfile
@@ -18,9 +18,7 @@ gem "sinatra", "~>2.2"
 gem "webrick", "~> 1.7"
 
 group :test do
-  gem "capybara"
   gem "faraday"
-  gem "poltergeist"
   gem "rspec"
   gem "rspec_junit_formatter"
 end

--- a/appengine/standard-metadata-server/Gemfile
+++ b/appengine/standard-metadata-server/Gemfile
@@ -22,4 +22,5 @@ group :test do
   gem "poltergeist"
   gem "rspec"
   gem "rspec_junit_formatter"
+  gem "faraday"
 end

--- a/appengine/standard-metadata-server/Gemfile
+++ b/appengine/standard-metadata-server/Gemfile
@@ -19,8 +19,8 @@ gem "webrick", "~> 1.7"
 
 group :test do
   gem "capybara"
+  gem "faraday"
   gem "poltergeist"
   gem "rspec"
   gem "rspec_junit_formatter"
-  gem "faraday"
 end

--- a/appengine/standard-metadata-server/Gemfile.lock
+++ b/appengine/standard-metadata-server/Gemfile.lock
@@ -14,6 +14,10 @@ GEM
       xpath (~> 3.2)
     cliver (0.3.2)
     diff-lcs (1.5.0)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     matrix (0.4.2)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
@@ -68,6 +72,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  faraday
   poltergeist
   rspec
   rspec_junit_formatter

--- a/appengine/standard-metadata-server/Gemfile.lock
+++ b/appengine/standard-metadata-server/Gemfile.lock
@@ -1,43 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    capybara (3.37.1)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
-    cliver (0.3.2)
     diff-lcs (1.5.0)
     faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    matrix (0.4.2)
-    mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nokogiri (1.13.6)
-      mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
-    public_suffix (4.0.7)
-    racc (1.6.0)
     rack (2.2.3)
     rack-protection (2.2.0)
       rack
-    rack-test (1.1.0)
-      rack (>= 1.0, < 3)
-    regexp_parser (2.4.0)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -61,19 +34,12 @@ GEM
       tilt (~> 2.0)
     tilt (2.0.10)
     webrick (1.7.0)
-    websocket-driver (0.7.5)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  capybara
   faraday
-  poltergeist
   rspec
   rspec_junit_formatter
   sinatra (~> 2.2)

--- a/appengine/standard-metadata-server/spec/metadata_server_spec.rb
+++ b/appengine/standard-metadata-server/spec/metadata_server_spec.rb
@@ -14,10 +14,7 @@
 
 require File.expand_path("../../../spec/e2e", __dir__)
 require "rspec"
-require "capybara/rspec"
-require "capybara/poltergeist"
-
-Capybara.default_driver = :poltergeist
+require 'faraday'
 
 describe "Metadata server on Google App Engine", type: :feature do
   before :all do
@@ -27,9 +24,9 @@ describe "Metadata server on Google App Engine", type: :feature do
   end
 
   it "displays zone read from metadata server" do
-    visit @url
+    response = Faraday.get(@url)
 
-    expect(page.body).to match(
+    expect(response.body).to match(
       /Zone: .*/
     )
   end

--- a/appengine/standard-metadata-server/spec/metadata_server_spec.rb
+++ b/appengine/standard-metadata-server/spec/metadata_server_spec.rb
@@ -24,7 +24,7 @@ describe "Metadata server on Google App Engine", type: :feature do
   end
 
   it "displays zone read from metadata server" do
-    response = Faraday.get(@url)
+    response = Faraday.get @url
 
     expect(response.body).to match(
       /Zone: .*/

--- a/appengine/standard-metadata-server/spec/metadata_server_spec.rb
+++ b/appengine/standard-metadata-server/spec/metadata_server_spec.rb
@@ -14,7 +14,7 @@
 
 require File.expand_path("../../../spec/e2e", __dir__)
 require "rspec"
-require 'faraday'
+require "faraday"
 
 describe "Metadata server on Google App Engine", type: :feature do
   before :all do


### PR DESCRIPTION
This PR addresses part of #1096.

It changes some of the tests to use simple HTTP client calls, instead of a headless browser.

There is no need to rely on a headless browser when we aren't simulating UI interactions. It adds unnecessary overhead and flakiness to the tests. 