### PR TITLE
docs: update custom timeout and retry sample

### DIFF
--- a/spanner/spanner_samples.rb
+++ b/spanner/spanner_samples.rb
@@ -2353,9 +2353,9 @@ def set_custom_timeout_and_retry project_id:, instance_id:, database_id:
   timeout = 60.0
   retry_policy = {
     initial_delay: 0.5,
-    max_delay:     64.0,
+    max_delay:     16.0,
     multiplier:    1.5,
-    retry_codes:   ["UNAVAILABLE", "DEADLINE_EXCEEDED"]
+    retry_codes:   ["UNAVAILABLE"]
   }
   call_options = { timeout: timeout, retry_policy: retry_policy }
 


### PR DESCRIPTION
Fixes a couple of minor issues in the retry- and timeout sample:

1. Remove DeadlineExceeded as a retryable code, as the sample uses a single timeout and will not retry on DeadlineExceeded anyways, meaning that the addition of that error code was just confusing.
1. Update the maxBackoff to 16 seconds. We are setting this value to 16 seconds for all client libraries, as it makes the sample confusing when the max backoff is larger than the total timeout (60 seconds).

The documentation page that uses this sample is https://cloud.google.com/spanner/docs/custom-timeout-and-retry

Do not merge: Please hold off on merging until all the samples have been updated.