### PR TITLE
fix: update cleanup to use the same version name

### DIFF
--- a/spec/e2e.rb
+++ b/spec/e2e.rb
@@ -43,8 +43,8 @@ class E2E
     def deploy test_dir, build_id = nil
       build_id ||= rand 1000..9999
 
-      test_name = versionize test_dir
-      version = "#{test_name}-#{build_id}"
+      @test_name = versionize test_dir
+      version = "#{@test_name}-#{build_id}"
 
       # read in our credentials file
       key_path = File.expand_path ENV["GOOGLE_APPLICATION_CREDENTIALS"], __FILE__
@@ -92,8 +92,7 @@ class E2E
       end
 
       # run gcloud command
-      test_name = versionize test_dir
-      exec "gcloud app versions delete #{test_name}-#{build_id} -q"
+      exec "gcloud app versions delete #{@test_name}-#{build_id} -q"
 
       # return the result of the gcloud delete command
       if $CHILD_STATUS.to_i != 0


### PR DESCRIPTION
- the random char added on versionize(https://github.com/GoogleCloudPlatform/ruby-docs-samples/pull/1097) was giving a different name when trying to cleanup leading to versions not being cleaned up properly after runs.

## Description

fixes #1184 
fixes #1158 

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] **Tests** pass
- [ ] **Lint** pass: `bundle exec rubocop`
- [ ] Please **merge** this PR for me once it is approved.
