### PR TITLE
chore: Use the bundled bundler rather than installing the latest

### DIFF
--- a/.kokoro/system_tests.sh
+++ b/.kokoro/system_tests.sh
@@ -17,7 +17,7 @@ source $KOKORO_GFILE_DIR/secrets.sh
 cd github/ruby-docs-samples/
 
 # Install tools
-gem install --no-document bundler toys
+gem install --no-document toys
 
 # Run the CI script
 toys kokoro-ci -v


### PR DESCRIPTION
Should fix the CI. The latest bundler 2.5 drops Ruby 2.7 compatibility, so the "Ruby Oldest" job can't install it, but we shouldn't actually need to install bundler explicitly anyway because all Ruby versions we test against have some version of bundler 2.x preinstalled.