### PR TITLE
Update app.yaml to work with latest ruby

### DIFF
--- a/appengine/rails-cloudsql-mysql/app.yaml
+++ b/appengine/rails-cloudsql-mysql/app.yaml
@@ -18,6 +18,10 @@
 entrypoint: bundle exec rackup --port $PORT
 env: flex
 runtime: ruby
+
+# Needed to enable latest rubies 3.2 and 3.3
+runtime_config:
+  operating_system: "ubuntu22"
 # [END step_1]
 
 env_variables:


### PR DESCRIPTION
Note that without this addon, the tutorial is currently broken.  See b/365178099

## Problem

I'm running this tutorial https://cloud.google.com/ruby/rails/using-cloudsql-postgres and it appears unable to run gcloud app deploy. The rrror is:

```
╔════════════════════════════════════════════════════════════╗
╠═ Uploading 2777 files to Google Cloud Storage             ═╣
╚════════════════════════════════════════════════════════════╝
File upload done.
ERROR: (gcloud.app.deploy) INVALID_ARGUMENT: Error(s) encountered validating runtime. Your runtime version for ruby is past End of Support. Please upgrade to the latest runtime version available..
- '@type': [type.googleapis.com/google.rpc.DebugInfo](http://type.googleapis.com/google.rpc.DebugInfo)
  detail: '[ORIGINAL ERROR] generic::invalid_argument: com.google.net.rpc3.RpcException:
    generic::INVALID_ARGUMENT: Error(s) encountered validating runtime. Your runtime
    version for ruby is past End of Support. Please upgrade to the latest runtime
    version available.. [google.rpc.error_details_ext] { code: 3 message: "Error(s)
    encountered validating runtime. Your runtime version for ruby is past End of Support.
    Please upgrade to the latest runtime version available.." }'
```

By looking at GAE Flex Rubies, looks like 3.2 and 3.3 need Ubuntu22.
So this patch should solve (and its solving in my test). 

## Description

Fixes #<ISSUE-NUMBER>

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] **Tests** pass
- [ ] **Lint** pass: `bundle exec rubocop`
- [ ] Please **merge** this PR for me once it is approved.
