### PR TITLE
Update production.rb to use :google GCS config

### DIFF
--- a/run/rails/config/environments/production.rb
+++ b/run/rails/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
-  config.active_storage.service = :local
+  # config.active_storage.service = :local
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/ruby-docs-samples/issues/1478 

Note there are TWO configs and we want :google for GCS to work.

## Description

Fixes #<ISSUE-NUMBER>

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] **Tests** pass
- [ ] **Lint** pass: `bundle exec rubocop`
- [ ] Please **merge** this PR for me once it is approved.
