### PR TITLE
feat: Add samples for backup schedule feature APIs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,5 @@ group :development, :test do
   gem "minitest-focus", "~> 1.1"
   gem "minitest-junit"
   gem "rake", "~> 13.0"
+  gem "rspec"
 end

--- a/spanner/spanner_create_full_backup_schedule_config.rb
+++ b/spanner/spanner_create_full_backup_schedule_config.rb
@@ -1,0 +1,53 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START spanner_create_full_backup_schedule_config]
+require "google/cloud/spanner/admin/database/v1"
+
+##
+# This is a snippet for showcasing how to create a schedule for full backups.
+#
+# @param project_id  [String] The ID of the Google Cloud project.
+# @param instance_id [String] The ID of the spanner instance.
+# @param database_id [String] The ID of the database.
+# @param backup_schedule_id [String] The ID of the backup schedule to be created.
+#
+def spanner_create_full_backup_schedule project_id:, instance_id:, database_id:, backup_schedule_id:
+  client = Google::Cloud::Spanner::Admin::Database.database_admin project_id: project_id
+  db_path = client.database_path project: project_id, instance: instance_id, database: database_id
+  database = client.get_database name: db_path
+
+  cron_spec = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdmin::CrontabSpec.new text: "30 12 * * *"
+  backup_schedule_spec = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdmin::BackupScheduleSpec.new cron_spec: cron_spec
+
+  encryption_config = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdmin::CreateBackupEncryptionConfig::EncryptionType.USE_DATABASE_ENCRYPTION
+
+  backup_schedule = {
+    full_backup_schedule: Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdmin::FullBackupSpec.new,
+    retention_duration: Google::Protobuf::Duration.new(seconds: 3600 * 24),
+    spec: backup_schedule_spec,
+    encryption_config: encryption_config
+  }
+
+  request = {
+    parent: database.name,
+    backup_schedule_id: backup_schedule_id,
+    backup_schedule: backup_schedule
+  }
+
+  created_backup_schedule = client.create_backup_schedule request
+  puts "Created full backup schedule for #{created_backup_schedule.name}"
+  puts created_backup_schedule
+end
+# [END spanner_create_full_backup_schedule_config]

--- a/spanner/spanner_create_incremental_backup_schedule_config.rb
+++ b/spanner/spanner_create_incremental_backup_schedule_config.rb
@@ -1,0 +1,53 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START spanner_create_incremental_backup_schedule_config]
+require "google/cloud/spanner/admin/database/v1"
+
+##
+# This is a snippet for showcasing how to create a schedule for incremental backups.
+#
+# @param project_id  [String] The ID of the Google Cloud project.
+# @param instance_id [String] The ID of the spanner instance.
+# @param database_id [String] The ID of the database.
+# @param backup_schedule_id [String] The ID of the backup schedule to be created.
+#
+def spanner_create_incremental_backup_schedule project_id:, instance_id:, database_id:, backup_schedule_id:
+  client = Google::Cloud::Spanner::Admin::Database.database_admin project_id: project_id
+  db_path = client.database_path project: project_id, instance: instance_id, database: database_id
+  database = client.get_database name: db_path
+
+  cron_spec = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdmin::CrontabSpec.new text: "30 12 * * *"
+  backup_schedule_spec = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdmin::BackupScheduleSpec.new cron_spec: cron_spec
+
+  encryption_config = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdmin::CreateBackupEncryptionConfig::EncryptionType.GOOGLE_DEFAULT_ENCRYPTION
+
+  backup_schedule = {
+    incremental_backup_schedule: Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdmin::IncrementalBackupSpec.new,
+    retention_duration: Google::Protobuf::Duration.new(seconds: 3600 * 24),
+    spec: backup_schedule_spec,
+    encryption_config: encryption_config
+  }
+
+  request = {
+    parent: database.name,
+    backup_schedule_id: backup_schedule_id,
+    backup_schedule: backup_schedule
+  }
+
+  created_backup_schedule = client.create_backup_schedule request
+  puts "Created incremental backup schedule for #{created_backup_schedule.name}"
+  puts created_backup_schedule
+end
+# [END spanner_create_incremental_backup_schedule_config]

--- a/spanner/spanner_delete_backup_schedule_config.rb
+++ b/spanner/spanner_delete_backup_schedule_config.rb
@@ -1,0 +1,37 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START spanner_delete_backup_schedule_config]
+require "google/cloud/spanner/admin/database/v1"
+
+##
+# This is a snippet for showcasing how to delete a schedule for creating backups.
+#
+# @param project_id  [String] The ID of the Google Cloud project.
+# @param instance_id [String] The ID of the spanner instance.
+# @param database_id [String] The ID of the database.
+# @param backup_schedule_id [String] The ID of the backup schedule to be created.
+#
+def spanner_delete_backup_schedule project_id:, instance_id:, database_id:, backup_schedule_id:
+  client = Google::Cloud::Spanner::Admin::Database.database_admin project_id: project_id
+  backup_schedule_name = "#{project_id}_#{instance_id}_#{database_id}_#{backup_schedule_id}"
+
+  request = {
+    backup_schedule_name: backup_schedule_name
+  }
+
+  client.delete_backup_schedule request
+  puts "Deleted backup schedule for #{backup_schedule_name}"
+end
+# [END spanner_delete_backup_schedule_config]

--- a/spanner/spanner_get_backup_schedule_config.rb
+++ b/spanner/spanner_get_backup_schedule_config.rb
@@ -1,0 +1,38 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START spanner_get_backup_schedule_config]
+require "google/cloud/spanner/admin/database/v1"
+
+##
+# This is a snippet for showcasing how to get a schedule for creating backups.
+#
+# @param project_id  [String] The ID of the Google Cloud project.
+# @param instance_id [String] The ID of the spanner instance.
+# @param database_id [String] The ID of the database.
+# @param backup_schedule_id [String] The ID of the backup schedule to be created.
+#
+def spanner_get_backup_schedule project_id:, instance_id:, database_id:, backup_schedule_id:
+  client = Google::Cloud::Spanner::Admin::Database.database_admin project_id: project_id
+  backup_schedule_name = "#{project_id}_#{instance_id}_#{database_id}_#{backup_schedule_id}"
+
+  request = {
+    backup_schedule_name: backup_schedule_name
+  }
+
+  backup_schedule = client.get_backup_schedule request
+  puts "Backup schedule: #{backup_schedule.name}"
+  puts backup_schedule
+end
+# [END spanner_get_backup_schedule_config]

--- a/spanner/spanner_list_backup_schedules_config.rb
+++ b/spanner/spanner_list_backup_schedules_config.rb
@@ -1,0 +1,38 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START spanner_list_backup_schedules_config]
+require "google/cloud/spanner/admin/database/v1"
+
+##
+# This is a snippet for showcasing how to get list of schedules for creating backups of a database.
+#
+# @param project_id  [String] The ID of the Google Cloud project.
+# @param instance_id [String] The ID of the spanner instance.
+# @param database_id [String] The ID of the database.
+# @param backup_schedule_id [String] The ID of the backup schedule to be created.
+#
+def spanner_list_backup_schedules project_id:, instance_id:, database_id:, backup_schedule_id:
+  client = Google::Cloud::Spanner::Admin::Database.database_admin project_id: project_id
+  backup_schedule_name = "#{project_id}_#{instance_id}_#{database_id}_#{backup_schedule_id}"
+
+  request = {
+    backup_schedule_name: backup_schedule_name
+  }
+
+  backup_schedule = client.get_backup_schedule request
+  puts "Backup schedule: #{backup_schedule.name}"
+  puts backup_schedule
+end
+# [END spanner_get_backup_schedule_config]

--- a/spanner/spec/spanner_backup_schedule_spec.rb
+++ b/spanner/spec/spanner_backup_schedule_spec.rb
@@ -1,0 +1,54 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "./spec_helper"
+require_relative "../spanner_create_full_backup_schedule_config"
+require_relative "../spanner_create_incremental_backup_schedule_config"
+require_relative "../spanner_delete_backup_schedule_config"
+
+describe "Spanner schedule for backups" do
+  project_id = @project_id
+  instance_id = @instance_id
+  database_id = @database_id
+  backup_schedule_id = @backup_schedule_id
+  backup_schedule_name = "#{project_id}_#{instance_id}_#{database_id}_#{backup_schedule_id}"
+
+  example "Create full backup schedule" do        
+    capture do
+      spanner_create_full_backup_schedule project_id: project_id, instance_id: instance_id, database_id: database_id, backup_schedule_id: backup_schedule_id
+    end
+    expect(captured_output).to include "Created full backup schedule for #{backup_schedule_name}"
+  end
+
+  example "Create incremental backup schedule" do
+    capture do
+      spanner_create_incremental_backup_schedule project_id: project_id, instance_id: instance_id, database_id: database_id, backup_schedule_id: backup_schedule_id
+    end
+    expect(captured_output).to include "Created incremental backup schedule for #{backup_schedule_name}"
+  end
+
+  example "Delete backup schedule" do
+    capture do
+      spanner_delete_backup_schedule project_id: project_id, instance_id: instance_id, database_id: database_id, backup_schedule_id: backup_schedule_id
+    end
+    expect(captured_output).to include "Deleted backup schedule for #{backup_schedule_name}"
+  end
+
+  example "Get backup schedule" do
+    capture do
+      spanner_get_backup_schedule project_id: project_id, instance_id: instance_id, database_id: database_id, backup_schedule_id: backup_schedule_id
+    end
+    expect(captured_output).to include "Backup schedule: #{backup_schedule_name}"
+  end
+end

--- a/spanner/spec/spec_helper.rb
+++ b/spanner/spec/spec_helper.rb
@@ -35,6 +35,7 @@ RSpec.configure do |config|
     @instance             = @spanner.instance @instance_id
     @mr_instance_id       = ENV["GOOGLE_CLOUD_SPANNER_MR_TEST_INSTANCE"]
     @mr_instance          = @spanner.instance @mr_instance_id
+    @backup_schedule_id   = "test_schedule_#{seed}"
     @created_instance_ids = []
     @created_instance_config_ids = []
     # A list of KMS key names to be used with CMEK


### PR DESCRIPTION
This PR adds code samples for the following APIs:

1. CreateBackupSchedule (both full and incremental backup schedules)
2. ListBackupSchedules
3. GetBackupSchedule
4. UpdateBackupSchedule
5. DeleteBackupSchedule