### PR TITLE
feat: update Cloud Run samples to use Artifact Registry

### DIFF
--- a/eventarc/generic/README.md
+++ b/eventarc/generic/README.md
@@ -9,13 +9,26 @@ This sample shows how to create a service that receives and prints generic event
 
 ## Quickstart
 
+Set your environment variables:
+
+```
+export GOOGLE_CLOUD_PROJECT=<PROJECT_ID>
+export GOOGLE_CLOUD_REGION=<REGION>
+```
+
+Create an Artifact Registry:
+
+```
+gcloud artifacts repositories create containers --repository-format docker --location ${GOOGLE_CLOUD_REGION}
+```
+
 Deploy your Cloud Run service:
 
 ```
 gcloud builds submit \
- --tag gcr.io/$(gcloud config get-value project)/eventarc-generic
+ --tag ${GOOGLE_CLOUD_REGION}-docker.pkg.dev/${GOOGLE_CLOUD_PROJECT}/containers/eventarc-generic
 gcloud run deploy eventarc-generic \
- --image gcr.io/$(gcloud config get-value project)/eventarc-generic
+ --image ${GOOGLE_CLOUD_REGION}-docker.pkg.dev/${GOOGLE_CLOUD_PROJECT}/containers/eventarc-generic
 ```
 
 ## Test

--- a/eventarc/generic/e2e_test_setup.yaml
+++ b/eventarc/generic/e2e_test_setup.yaml
@@ -15,11 +15,11 @@
 steps:
 - # Build the renderer image
   name: gcr.io/cloud-builders/docker:latest
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/eventarc-${_SUFFIX}', '.']
+  args: ['build', '--tag=us-docker.pkg.dev/$PROJECT_ID/containers/eventarc-${_SUFFIX}', '.']
 
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/eventarc-${_SUFFIX}']
+  args: ['push', 'us-docker.pkg.dev/$PROJECT_ID/containers/eventarc-${_SUFFIX}']
 
 - # Deploy to Cloud Run
   name: gcr.io/google.com/cloudsdktool/cloud-sdk
@@ -28,11 +28,11 @@ steps:
   - run
   - deploy
   - eventarc-${_SUFFIX}
-  - --image=gcr.io/$PROJECT_ID/eventarc-${_SUFFIX}
+  - --image=us-docker.pkg.dev/$PROJECT_ID/containers/eventarc-${_SUFFIX}
   - --region=us-central1
   - --platform=managed
   - --no-allow-unauthenticated
   - --set-env-vars=NAME=Test
 
 images:
-  - 'gcr.io/$PROJECT_ID/eventarc-${_SUFFIX}'
+  - 'us-docker.pkg.dev/$PROJECT_ID/containers/eventarc-${_SUFFIX}'

--- a/eventarc/pubsub/e2e_test_setup.yaml
+++ b/eventarc/pubsub/e2e_test_setup.yaml
@@ -15,11 +15,11 @@
 steps:
 - # Build the renderer image
   name: gcr.io/cloud-builders/docker:latest
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/eventarc-${_SUFFIX}', '.']
+  args: ['build', '--tag=us-docker.pkg.dev/$PROJECT_ID/containers/eventarc-${_SUFFIX}', '.']
 
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/eventarc-${_SUFFIX}']
+  args: ['push', 'us-docker.pkg.dev/$PROJECT_ID/containers/eventarc-${_SUFFIX}']
 
 - # Deploy to Cloud Run
   name: gcr.io/google.com/cloudsdktool/cloud-sdk
@@ -28,11 +28,11 @@ steps:
   - run
   - deploy
   - eventarc-${_SUFFIX}
-  - --image=gcr.io/$PROJECT_ID/eventarc-${_SUFFIX}
+  - --image=us-docker.pkg.dev/$PROJECT_ID/containers/eventarc-${_SUFFIX}
   - --region=us-central1
   - --platform=managed
   - --no-allow-unauthenticated
   - --set-env-vars=NAME=Test
 
 images:
-  - 'gcr.io/$PROJECT_ID/eventarc-${_SUFFIX}'
+  - 'us-docker.pkg.dev/$PROJECT_ID/containers/eventarc-${_SUFFIX}'

--- a/run/README.md
+++ b/run/README.md
@@ -22,6 +22,12 @@ For more Cloud Run samples beyond Ruby, see the main list in the [Cloud Run Samp
     git clone https://github.com/GoogleCloudPlatform/ruby-docs-samples.git
     ```
 
+1. Create an Artifact Registry:
+
+    ```sh
+    gcloud artifacts repositories create containers --repository-format docker --location ${GOOGLE_CLOUD_REGION}
+    ```
+
 ## How to run a sample locally
 
 1. [Install docker locally](https://docs.docker.com/install/)
@@ -75,14 +81,14 @@ For more Cloud Run samples beyond Ruby, see the main list in the [Cloud Run Samp
 1. Build your container image using Cloud Build, by running the following command from the directory containing the Dockerfile:
 
     ```sh
-    gcloud builds submit --tag gcr.io/${GOOGLE_CLOUD_PROJECT}/${SAMPLE}
+    gcloud builds submit --tag ${GOOGLE_CLOUD_REGION}-docker.pkg.dev/${GOOGLE_CLOUD_PROJECT}/containers/${SAMPLE}
     ```
 
 1. Deploy the container image using the following command:
 
     ```sh
     gcloud run deploy ${SAMPLE} \
-      --image gcr.io/${GOOGLE_CLOUD_PROJECT}/${SAMPLE}
+      --image ${GOOGLE_CLOUD_REGION}-docker.pkg.dev/${GOOGLE_CLOUD_PROJECT}/containers/${SAMPLE}
     ```
 
 See [Building containers][run_build] and [Deploying container images][run_deploy]

--- a/run/helloworld/README.md
+++ b/run/helloworld/README.md
@@ -16,6 +16,11 @@ This sample shows how to deploy a Hello World application to Cloud Run.
     ```sh
     git clone https://github.com/GoogleCloudPlatform/ruby-docs-samples.git
     ```
+1. Create an Artifact Registry:
+
+    ```sh
+    gcloud artifacts repositories create containers --repository-format docker --location ${GOOGLE_CLOUD_REGION}
+    ```
 
 ## Build
 
@@ -48,11 +53,14 @@ bundle exec rspec
 # Set an environment variable with your GCP Project ID
 export GOOGLE_CLOUD_PROJECT=<PROJECT_ID>
 
+# Set an environment variable with your Google Cloud region
+export GOOGLE_CLOUD_REGION=<REGION>
+
 # Submit a build using Google Cloud Build
-gcloud builds submit --tag gcr.io/${GOOGLE_CLOUD_PROJECT}/helloworld
+gcloud builds submit --tag ${GOOGLE_CLOUD_REGION}-docker.pkg.dev/${GOOGLE_CLOUD_PROJECT}/containers/helloworld
 
 # Deploy to Cloud Run
-gcloud run deploy helloworld --image gcr.io/${GOOGLE_CLOUD_PROJECT}/helloworld
+gcloud run deploy helloworld --image ${GOOGLE_CLOUD_REGION}-docker.pkg.dev/${GOOGLE_CLOUD_PROJECT}/containers/helloworld
 ```
 
 Visit your deployed container by opening the service URL in a web browser.

--- a/run/helloworld/e2e_test_setup.yaml
+++ b/run/helloworld/e2e_test_setup.yaml
@@ -15,11 +15,11 @@
 steps:
 - # Build the renderer image
   name: gcr.io/cloud-builders/docker:latest
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/helloworld-${_SUFFIX}', '.']
+  args: ['build', '--tag=us-docker.pkg.dev/$PROJECT_ID/containers/helloworld-${_SUFFIX}', '.']
 
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/helloworld-${_SUFFIX}']
+  args: ['push', 'us-docker.pkg.dev/$PROJECT_ID/containers/helloworld-${_SUFFIX}']
 
 - # Deploy to Cloud Run
   name: gcr.io/google.com/cloudsdktool/cloud-sdk
@@ -28,11 +28,11 @@ steps:
   - run
   - deploy
   - helloworld-${_SUFFIX}
-  - --image=gcr.io/$PROJECT_ID/helloworld-${_SUFFIX}
+  - --image=us-docker.pkg.dev/$PROJECT_ID/containers/helloworld-${_SUFFIX}
   - --region=us-central1
   - --platform=managed
   - --no-allow-unauthenticated
   - --set-env-vars=NAME=Test
 
 images:
-  - 'gcr.io/$PROJECT_ID/helloworld-${_SUFFIX}'
+  - 'us-docker.pkg.dev/$PROJECT_ID/containers/helloworld-${_SUFFIX}'


### PR DESCRIPTION
## Description

Fixes periodic test failures (#1497)

Updates Container Registry references in Cloud Run and Eventarc sample to Artifact Registry. (Rails on Cloud Run sample updated else where in #1495)

## Checklist
- [x]  Infrastructure required: These tests introduce the `containers` Artifact Registry in the `us` multi-region. This registry needs to be created in all test projects for this PR to pass.  **Update**: this has been added. 
- [x] **Tests** pass
- [x] **Lint** pass: `bundle exec rubocop`
- [x] Please **merge** this PR for me once it is approved.
