### PR TITLE
fix(appengine/standard-storage): refactor capybara testing

### DIFF
--- a/appengine/standard-storage/app.rb
+++ b/appengine/standard-storage/app.rb
@@ -16,6 +16,12 @@
 require "sinatra"
 require "google/cloud/storage"
 
+# [END gae_standard_storage_app]
+configure :development do
+  set :host_authorization, { permitted_hosts: [] }
+end
+# [START gae_standard_storage_app]
+
 storage = Google::Cloud::Storage.new
 bucket  = storage.bucket ENV["GOOGLE_CLOUD_STORAGE_BUCKET"]
 

--- a/appengine/standard-storage/app.rb
+++ b/appengine/standard-storage/app.rb
@@ -20,8 +20,8 @@ require "google/cloud/storage"
 configure :development do
   set :host_authorization, { permitted_hosts: [] }
 end
-# [START gae_standard_storage_app]
 
+# [START gae_standard_storage_app]
 storage = Google::Cloud::Storage.new
 bucket  = storage.bucket ENV["GOOGLE_CLOUD_STORAGE_BUCKET"]
 

--- a/appengine/standard-storage/spec/storage_spec.rb
+++ b/appengine/standard-storage/spec/storage_spec.rb
@@ -19,7 +19,9 @@ require "capybara/cuprite"
 
 describe "Cloud Storage", type: :feature do
   before do
-    Capybara.current_driver = :cuprite
+    Capybara.register_driver :cuprite do |app|
+      Capybara::Cuprite::Driver.new(app, browser_options: {'no-sandbox': nil})
+    end
   end
   it "can upload and get public URL of uploaded file" do
     Capybara.app = Sinatra::Application
@@ -31,7 +33,7 @@ describe "Cloud Storage", type: :feature do
 
     uploaded_file_public_url = page.find("body").text
 
-    visit uploaded_file_public_url
-    expect(page).to have_content "This is the content of the test-upload.txt file"
+    page = Net::HTTP.get_response(URI(uploaded_file_public_url))
+    expect(page.body).to include "This is the content of the test-upload.txt file"
   end
 end


### PR DESCRIPTION
## Description

Resolves issues in updates to the testing stack. 

 * Ensure host authorization for all hosts while in development (solves for "Host not permitted")
 * Use `no-sandbox` flag to ensure successful execution in Docker (presents timeouts)
 * Use `NET::HTTP` for external URL validation (presents `visit`'s host limitation)

Internal b/392885740

Would appreciate review and confirmation before applying to other samples in appengine/ space

## Checklist
- [x] **Tests** pass
- [x] **Lint** pass: `bundle exec rubocop`
- [ ] Please **merge** this PR for me once it is approved.
