### PR TITLE
chore: add cloud-samples-infra to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,12 +7,12 @@
 
 # The yoshi-ruby team is the default owner for anything not
 # explicitly taken by someone else.
-*                               @GoogleCloudPlatform/yoshi-ruby
+*                               @GoogleCloudPlatform/yoshi-ruby @GoogleCloudPlatform/cloud-samples-infra
 
 /cloud-sql/    @GoogleCloudPlatform/infra-db-sdk @GoogleCloudPlatform/yoshi-ruby
 /iot/          @GoogleCloudPlatform/api-iot @GoogleCloudPlatform/yoshi-ruby
 /jobs/         @GoogleCloudPlatform/ml-apis @GoogleCloudPlatform/yoshi-ruby
 
-# Self-service 
+# Self-service
 
 /appengine     @GoogleCloudPlatform/yoshi-ruby @GoogleCloudPlatform/serverless-runtimes


### PR DESCRIPTION
## Description

Addresses b/405801293

Team has previously been added to the repo, so CODEOWNERS file is valid.  


## Checklist
- [X] **Tests** pass
- [X] **Lint** pass: `bundle exec rubocop`
- [X] Please **merge** this PR for me once it is approved.
