### PR TITLE
chore: remove flakybot configuration (long retired)

### DIFF
--- a/.toys/kokoro-ci.rb
+++ b/.toys/kokoro-ci.rb
@@ -49,10 +49,6 @@ def report_results
     puts failure, :red, :bold
   end
   puts "Search these logs for the red test names listed above to see details."
-  unless presubmit?
-    chmod "+x", "#{gfile_dir}/linux_amd64/flakybot"
-    exec ["#{gfile_dir}/linux_amd64/flakybot"]
-  end
 end
 
 def run_cleanup


### PR DESCRIPTION
## Description

Addresses b/434770885 (Complete flakybot deprecation) for this repo.

## Checklist
- [ ] **Tests** pass
- [ ] **Lint** pass: `bundle exec rubocop`
- [X] Please **merge** this PR for me once it is approved.
