### PR TITLE
fix(run): Update sinatra so it is compatible with Ruby 4.0

### DIFF
--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -17,7 +17,7 @@
 
 # Use the official Ruby image.
 # https://hub.docker.com/_/ruby
-FROM ruby:3.4
+FROM ruby:4.0
 
 # Install production dependencies.
 WORKDIR /usr/src/app

--- a/run/helloworld/Gemfile
+++ b/run/helloworld/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "sinatra", "~>3.1"
+gem "sinatra", "~>4.2"
 gem "thin"
 
 group :test do
@@ -13,4 +13,4 @@ group :test do
 end
 
 gem "puma", "~> 6.6"
-gem "rackup", "~> 1.0"
+gem "rackup", "~> 2.0"

--- a/run/helloworld/Gemfile.lock
+++ b/run/helloworld/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    base64 (0.3.0)
     daemons (1.4.1)
     diff-lcs (1.5.0)
     domain_name (0.5.20190701)
@@ -9,23 +10,27 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
+    logger (1.7.0)
     mime-types (3.5.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0808)
-    mustermann (3.0.0)
-      ruby2_keywords (~> 0.0.1)
+    mustermann (3.1.1)
     netrc (0.11.0)
     nio4r (2.7.4)
     puma (6.6.0)
       nio4r (~> 2.0)
-    rack (2.2.8.1)
-    rack-protection (3.1.0)
-      rack (~> 2.2, >= 2.2.4)
+    rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.3.1)
+      rack (>= 3)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -48,22 +53,23 @@ GEM
     rspec-support (3.12.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    ruby2_keywords (0.0.5)
     rubysl-securerandom (2.0.0)
-    sinatra (3.1.0)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
       mustermann (~> 3.0)
-      rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.1.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    thin (1.8.2)
+    thin (2.0.1)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
-    tilt (2.2.0)
+      logger
+      rack (>= 1, < 4)
+    tilt (2.7.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    webrick (1.9.1)
 
 PLATFORMS
   ruby
@@ -71,13 +77,13 @@ PLATFORMS
 DEPENDENCIES
   puma (~> 6.6)
   rack-test
-  rackup (~> 1.0)
+  rackup (~> 2.0)
   rest-client
   rspec
   rspec-retry
   rspec_junit_formatter
   rubysl-securerandom
-  sinatra (~> 3.1)
+  sinatra (~> 4.2)
   thin
 
 BUNDLED WITH

--- a/run/helloworld/app.rb
+++ b/run/helloworld/app.rb
@@ -20,6 +20,10 @@ set :bind, "0.0.0.0"
 port = ENV["PORT"] || "8080"
 set :port, port
 
+# Sinatra 4.1+ enables HostAuthorization by default.
+# Explicitly permit localhost and Cloud Run domains.
+set :host_authorization, { permitted_hosts: [".run.app", "localhost"] }
+
 get "/" do
   name = ENV["NAME"] || "World"
   "Hello #{name}!"

--- a/run/helloworld/spec/helloworld_spec.rb
+++ b/run/helloworld/spec/helloworld_spec.rb
@@ -25,13 +25,13 @@ describe "Hello World" do
 
   it "Service uses default NAME" do
     ENV["NAME"] = nil
-    get "/"
+    get "/", {}, { "HTTP_HOST" => "localhost"}
     expect(last_response.body).to eq("Hello World!")
   end
 
   it "Service uses override NAME" do
     ENV["NAME"] = "Cloud"
-    get "/"
+    get "/", {}, { "HTTP_HOST" => "localhost"}
     expect(last_response.body).to eq("Hello Cloud!")
   end
 


### PR DESCRIPTION
## Description
This PR updates the helloworld app for Ruby 4.0 compatibility, which also required an upgrade to Sinatra. 

Sinatra 4.1+ now defaults to the `Rack::Protection::HostAuthorization` middleware. This triggered 403 Forbidden ("Host not permitted") errors across deployed Cloud Run services and E2E tests, as the application began strictly blocking any Host headers other than localhost, So now the code it explicitly says which domains are allowed.

Fixes Internal b/522468963

## Checklist
- [x] **Tests** pass
- [x] **Lint** pass: `bundle exec rubocop`
- [ ] Please **merge** this PR for me once it is approved.
