### PR TITLE
chore: autocorrect rubocop offenses in appengine and jobs samples

### DIFF
--- a/appengine/rails-hello_world/bin/setup
+++ b/appengine/rails-hello_world/bin/setup
@@ -4,7 +4,7 @@ require "fileutils"
 # path to your application root.
 APP_ROOT = File.expand_path "..", __dir__
 
-def system!(*args)
+def system! *args
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 

--- a/appengine/standard-static-files/rails/bin/setup
+++ b/appengine/standard-static-files/rails/bin/setup
@@ -18,7 +18,7 @@ require "fileutils"
 # path to your application root.
 APP_ROOT = File.expand_path "..", __dir__
 
-def system!(*args)
+def system! *args
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 

--- a/appengine/static_files/rails/bin/setup
+++ b/appengine/static_files/rails/bin/setup
@@ -18,7 +18,7 @@ require "fileutils"
 # path to your application root.
 APP_ROOT = File.expand_path "..", __dir__
 
-def system!(*args)
+def system! *args
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 

--- a/jobs/V3/filter_search_sample.rb
+++ b/jobs/V3/filter_search_sample.rb
@@ -230,16 +230,18 @@ def job_discovery_compensation_search project_id:, company_name:, min_unit:, max
                                                session_id: "HashedSessionId",
                                                domain:     "http://careers.google.com"
   # Search jobs that pay between min_unit and max_unit (USD/hour)
-  compensation_range = jobs::CompensationRange.new max_compensation: (
-    jobs::Money.new currency_code: "USD",
-                    units:         max_unit,
-                    nanos:         500_000_000
-  ),
-                                                   min_compensation: (
-                                                     jobs::Money.new currency_code: "USD",
-                                                                     units:         min_unit,
-                                                                     nanos:         0
-                                                   )
+  compensation_range = jobs::CompensationRange.new(
+    max_compensation: jobs::Money.new(
+      currency_code: "USD",
+      units:         max_unit,
+      nanos:         500_000_000
+    ),
+    min_compensation: jobs::Money.new(
+      currency_code: "USD",
+      units:         min_unit,
+      nanos:         0
+    )
+  )
   compensation_filter = jobs::CompensationFilter.new type:  "UNIT_AND_AMOUNT",
                                                      units: ["HOURLY"],
                                                      range: compensation_range

--- a/jobs/V3/filter_search_sample.rb
+++ b/jobs/V3/filter_search_sample.rb
@@ -231,10 +231,10 @@ def job_discovery_compensation_search project_id:, company_name:, min_unit:, max
                                                domain:     "http://careers.google.com"
   # Search jobs that pay between min_unit and max_unit (USD/hour)
   compensation_range = jobs::CompensationRange.new max_compensation: (
-                                                     jobs::Money.new currency_code: "USD",
-                                                                     units:         max_unit,
-                                                                     nanos:         500_000_000
-                                                   ),
+    jobs::Money.new currency_code: "USD",
+                    units:         max_unit,
+                    nanos:         500_000_000
+  ),
                                                    min_compensation: (
                                                      jobs::Money.new currency_code: "USD",
                                                                      units:         min_unit,


### PR DESCRIPTION
Fixes Rubocop errors reported in presubmit:
- appengine/rails-hello_world/bin/setup: Style/MethodDefParentheses
- appengine/standard-static-files/rails/bin/setup: Style/MethodDefParentheses
- appengine/static_files/rails/bin/setup: Style/MethodDefParentheses
- jobs/V3/filter_search_sample.rb: Layout/IndentationWidth, Layout/ClosingParenthesisIndentation

Autocorrected via Rubocop CLI (`bundle exec rubocop -a`).